### PR TITLE
Add LocalVfs: local-directory VFS with strict containment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,6 +1334,7 @@ dependencies = [
  "jaq-core",
  "jaq-json",
  "jaq-std",
+ "libc",
  "proptest",
  "regex",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,9 @@ serde_json = "1.0.150"
 tokio = { version = "1.52.3", default-features = false, features = ["rt", "time", "io-util", "sync"] }
 wasmtime = { version = "46.0.1", default-features = false, features = ["runtime", "cranelift", "std"], optional = true }
 
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+
 [dev-dependencies]
 proptest = "1.11.0"
 tokio = { version = "1.52.3", default-features = false, features = ["macros", "rt-multi-thread", "rt", "time", "io-util"] }

--- a/README.md
+++ b/README.md
@@ -65,19 +65,22 @@ console.assert(result.stdout === '1\n')
   - [Syscalls](#syscalls)
   - [JavaScript prelude](#javascript-prelude)
   - [Fetch](#fetch)
-- [Bring your own VFS](#bring-your-own-vfs)
+- [Local directory VFS](#local-directory-vfs)
   - [Rust](#rust-4)
   - [TypeScript](#typescript-4)
-  - [Rust lower-level VFS](#rust-5)
-  - [TypeScript lower-level VFS](#typescript-5)
+- [Bring your own VFS](#bring-your-own-vfs)
+  - [Rust](#rust-5)
+  - [TypeScript](#typescript-5)
+  - [Rust lower-level VFS](#rust-6)
+  - [TypeScript lower-level VFS](#typescript-6)
 - [Snapshots](#snapshots)
-  - [Rust](#rust-6)
-  - [TypeScript](#typescript-6)
-  - [Rust diffing](#rust-7)
-  - [TypeScript diffing](#typescript-7)
+  - [Rust](#rust-7)
+  - [TypeScript](#typescript-7)
+  - [Rust diffing](#rust-8)
+  - [TypeScript diffing](#typescript-8)
 - [Limits and observability](#limits-and-observability)
-  - [Rust](#rust-8)
-  - [TypeScript](#typescript-8)
+  - [Rust](#rust-9)
+  - [TypeScript](#typescript-9)
 - [Security model](#security-model)
 - [Comparison with just-bash](#comparison-with-just-bash)
 - [Performance](#performance)
@@ -575,6 +578,52 @@ const result = await sandbox.exec(
 console.assert(result.stdout === 'echo https://example.test/echo hi\n')
 ```
 
+## Local directory VFS
+
+On Unix hosts a second built-in filesystem, `LocalVfs`, roots the sandbox in
+a directory on the host disk. Files persist across sandboxes and process
+restarts, existing content in the directory is visible inside, and host
+tools can read what the agent writes.
+
+Containment is strict: every sandbox path resolves beneath the root (`..` is
+clamped by normalization before touching the OS), symbolic links are never
+followed (they are invisible to lookups and rejected with `O_NOFOLLOW` at
+open time), and special files are refused. The same quota knobs as
+`InMemoryVfs` apply, seeded by scanning the existing tree at construction.
+Dedicate the directory to the sandbox — containment holds regardless, but
+quota accounting assumes no other process mutates the tree while the sandbox
+is live. `LocalVfs` passes the same conformance suite as `InMemoryVfs`.
+
+#### Rust
+
+```rust ignore
+use tinysandbox::sandbox::Sandbox;
+use tinysandbox::vfs::{LocalVfs, VfsQuota};
+
+let sandbox = Sandbox::builder()
+    .vfs(LocalVfs::new("/srv/agent-42-workspace")?)
+    .build();
+
+// Or with quota limits:
+let quota = VfsQuota { max_bytes: 64 << 20, max_files: 4096, max_file_size: 16 << 20 };
+let sandbox = Sandbox::builder()
+    .vfs(LocalVfs::with_quota("/srv/agent-42-workspace", quota)?)
+    .build();
+```
+
+#### TypeScript
+
+```ts
+import { Sandbox } from '@tinysandbox/tinysandbox'
+
+const sandbox = new Sandbox({
+  localVfs: {
+    root: '/srv/agent-42-workspace',
+    quota: { maxBytes: 64 * 1024 * 1024 } // optional; unset limits are unlimited
+  }
+})
+```
+
 ## Bring your own VFS
 
 The filesystem is a trait, and the in-memory implementation is just the
@@ -759,7 +808,9 @@ reports VFS usage and total commands run.
   VFS, quotas, and path containment as everything else.
 - **Resources are bounded** per execution: memory (ResourceLimiter), CPU
   (epoch interruption), wall clock, output size, file quotas.
-- `..` traversal is contained at the VFS root; `/bin` is read-only.
+- `..` traversal is contained at the VFS root; `/bin` is read-only. With
+  the local directory VFS, containment also refuses symlinks and special
+  files, so the sandbox cannot reach outside its host directory.
 
 tinysandbox is one layer, not the whole story: for hostile multi-tenant
 workloads you should still run your process under OS-level defense in depth

--- a/README.md
+++ b/README.md
@@ -594,6 +594,14 @@ Dedicate the directory to the sandbox — containment holds regardless, but
 quota accounting assumes no other process mutates the tree while the sandbox
 is live. `LocalVfs` passes the same conformance suite as `InMemoryVfs`.
 
+When the host does legitimately touch the tree — or tracks usage out of band
+entirely — rebaseline the counters from outside the sandbox: `refresh()`
+rescans the directory, and `set_usage()` pushes externally computed numbers.
+Enforcement then just answers "should this write be blocked" against the
+current baseline, with live operations applying their deltas on top. From
+TypeScript: `await sandbox.refreshLocalVfs()` and
+`sandbox.setLocalVfsUsage({ usedBytes, fileCount })`.
+
 #### Rust
 
 ```rust ignore

--- a/src/sandbox/builtins.rs
+++ b/src/sandbox/builtins.rs
@@ -311,7 +311,6 @@ fn echo(ctx: CommandContext) -> CommandFuture {
         let CommandContext {
             args,
             mut stdout,
-            stderr: _,
             ..
         } = ctx;
         let mut newline = true;

--- a/src/sandbox/builtins.rs
+++ b/src/sandbox/builtins.rs
@@ -309,9 +309,7 @@ async fn cat_stream(
 fn echo(ctx: CommandContext) -> CommandFuture {
     boxed(async move {
         let CommandContext {
-            args,
-            mut stdout,
-            ..
+            args, mut stdout, ..
         } = ctx;
         let mut newline = true;
         let mut escapes = false;

--- a/src/vfs/local.rs
+++ b/src/vfs/local.rs
@@ -1,0 +1,585 @@
+//! Local-directory VFS that persists sandbox files under a host directory.
+
+use std::collections::BTreeMap;
+use std::fs::{self, File, OpenOptions};
+use std::io;
+use std::os::unix::fs::{FileExt, MetadataExt, OpenOptionsExt};
+use std::path::{Path, PathBuf};
+use std::sync::{Mutex, MutexGuard, PoisonError};
+
+use super::path::normalize_path;
+use super::{
+    DirEntry, Errno, FileHandle, FileType, Metadata, OpenMode, Vfs, VfsError, VfsQuota, VfsResult,
+    VfsStats,
+};
+
+/// Quota-enforced [`Vfs`] backed by a directory on the host filesystem.
+///
+/// Every sandbox path resolves strictly beneath the root directory given at
+/// construction: normalization clamps `..` at the sandbox root, and symbolic
+/// links are never followed. Symlinks, hard links to them, and special files
+/// (FIFOs, sockets, devices) are invisible — path lookups treat them as
+/// absent, `readdir` skips them, and opening one fails with `EACCES`.
+///
+/// Unlike [`InMemoryVfs`](crate::vfs::InMemoryVfs), contents persist on disk
+/// across instances: a new `LocalVfs` over the same root seeds its quota
+/// usage by scanning the existing tree. Existing content larger than the
+/// quota is tolerated; the quota only rejects further growth.
+///
+/// The root directory must be dedicated to the sandbox. Quota accounting and
+/// handle semantics assume no other process mutates the tree while the VFS is
+/// live; external writers can skew usage numbers but cannot break path
+/// containment.
+#[derive(Debug)]
+pub struct LocalVfs {
+    root: PathBuf,
+    quota: VfsQuota,
+    state: Mutex<State>,
+}
+
+impl LocalVfs {
+    /// Opens a local VFS rooted at an existing directory with no quota limits.
+    pub fn new(root: impl AsRef<Path>) -> io::Result<Self> {
+        Self::with_quota(root, VfsQuota::unlimited())
+    }
+
+    /// Opens a local VFS rooted at an existing directory, enforcing `quota`.
+    pub fn with_quota(root: impl AsRef<Path>, quota: VfsQuota) -> io::Result<Self> {
+        let root = fs::canonicalize(root)?;
+        if !fs::symlink_metadata(&root)?.is_dir() {
+            return Err(io::Error::new(
+                io::ErrorKind::NotADirectory,
+                "LocalVfs root must be a directory",
+            ));
+        }
+
+        let mut used_bytes = 0;
+        let mut file_count = 0;
+        scan_tree(&root, &mut used_bytes, &mut file_count)?;
+
+        Ok(Self {
+            root,
+            quota,
+            state: Mutex::new(State {
+                handles: BTreeMap::new(),
+                open_files: BTreeMap::new(),
+                next_handle: 1,
+                used_bytes,
+                file_count,
+            }),
+        })
+    }
+
+    /// Returns the canonicalized host directory backing this VFS.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    /// Returns current quota usage.
+    pub fn stats(&self) -> VfsResult<VfsStats> {
+        let state = self.state();
+        Ok(VfsStats {
+            used_bytes: state.used_bytes,
+            file_count: state.file_count,
+        })
+    }
+
+    fn state(&self) -> MutexGuard<'_, State> {
+        self.state.lock().unwrap_or_else(PoisonError::into_inner)
+    }
+
+    /// Maps a VFS path onto the host directory, verifying that every
+    /// intermediate component is a real directory (never a symlink).
+    fn resolve(&self, path: &str) -> VfsResult<PathBuf> {
+        let components = normalize_path(path)?;
+        let mut resolved = self.root.clone();
+
+        for (index, component) in components.iter().enumerate() {
+            resolved.push(component);
+            if index + 1 == components.len() {
+                break;
+            }
+            match lookup(&resolved)?.as_ref().map(entry_kind) {
+                Some(EntryKind::Directory) => {}
+                Some(EntryKind::File) => return Err(VfsError::new(Errno::ENOTDIR)),
+                Some(EntryKind::Other) | None => return Err(VfsError::new(Errno::ENOENT)),
+            }
+        }
+
+        Ok(resolved)
+    }
+
+    fn ensure_entry_slot(&self, state: &State) -> VfsResult<()> {
+        if state.file_count >= self.quota.max_files {
+            return Err(VfsError::new(Errno::ENOSPC));
+        }
+
+        Ok(())
+    }
+
+    /// Checks that resizing a file from `old_len` to `new_len` fits the quota
+    /// and returns the resulting total usage.
+    fn resized_usage(&self, used_bytes: u64, old_len: u64, new_len: u64) -> VfsResult<u64> {
+        if new_len > self.quota.max_file_size {
+            return Err(VfsError::new(Errno::ENOSPC));
+        }
+
+        let used_bytes = if new_len >= old_len {
+            used_bytes
+                .checked_add(new_len - old_len)
+                .ok_or(VfsError::new(Errno::ENOSPC))?
+        } else {
+            used_bytes.saturating_sub(old_len - new_len)
+        };
+        if used_bytes > self.quota.max_bytes {
+            return Err(VfsError::new(Errno::ENOSPC));
+        }
+
+        Ok(used_bytes)
+    }
+}
+
+impl Vfs for LocalVfs {
+    fn stats(&self) -> Option<VfsResult<VfsStats>> {
+        Some(LocalVfs::stats(self))
+    }
+
+    fn stat(&self, path: &str) -> VfsResult<Metadata> {
+        let resolved = self.resolve(path)?;
+        let _guard = self.state();
+        let meta = lookup(&resolved)?.ok_or(VfsError::new(Errno::ENOENT))?;
+        metadata_from(&meta).ok_or(VfsError::new(Errno::ENOENT))
+    }
+
+    fn readdir(&self, path: &str) -> VfsResult<Vec<DirEntry>> {
+        let resolved = self.resolve(path)?;
+        let _guard = self.state();
+        match lookup(&resolved)?.as_ref().map(entry_kind) {
+            Some(EntryKind::Directory) => {}
+            Some(EntryKind::File) => return Err(VfsError::new(Errno::ENOTDIR)),
+            Some(EntryKind::Other) | None => return Err(VfsError::new(Errno::ENOENT)),
+        }
+
+        let mut entries = Vec::new();
+        for entry in fs::read_dir(&resolved).map_err(|err| io_error(&err))? {
+            let entry = entry.map_err(|err| io_error(&err))?;
+            // Names the String-based VFS API cannot express are invisible.
+            let Ok(name) = entry.file_name().into_string() else {
+                continue;
+            };
+            let meta = match entry.metadata() {
+                Ok(meta) => meta,
+                Err(err) if err.kind() == io::ErrorKind::NotFound => continue,
+                Err(err) => return Err(io_error(&err)),
+            };
+            if let Some(metadata) = metadata_from(&meta) {
+                entries.push(DirEntry { name, metadata });
+            }
+        }
+        entries.sort_by(|a, b| a.name.cmp(&b.name));
+        Ok(entries)
+    }
+
+    fn mkdir(&self, path: &str) -> VfsResult<()> {
+        let resolved = self.resolve(path)?;
+        if resolved == self.root {
+            return Err(VfsError::new(Errno::EEXIST));
+        }
+
+        let mut state = self.state();
+        if lookup(&resolved)?.is_some() {
+            return Err(VfsError::new(Errno::EEXIST));
+        }
+        self.ensure_entry_slot(&state)?;
+
+        fs::create_dir(&resolved).map_err(|err| io_error(&err))?;
+        state.file_count += 1;
+        Ok(())
+    }
+
+    fn rename(&self, from: &str, to: &str) -> VfsResult<()> {
+        let from_resolved = self.resolve(from)?;
+        let to_resolved = self.resolve(to)?;
+        if from_resolved == self.root || to_resolved == self.root {
+            return Err(VfsError::new(Errno::EINVAL));
+        }
+
+        let mut guard = self.state();
+        let state = &mut *guard;
+        let source_kind = match lookup(&from_resolved)?.as_ref().map(entry_kind) {
+            Some(EntryKind::Other) | None => return Err(VfsError::new(Errno::ENOENT)),
+            Some(kind) => kind,
+        };
+        if from_resolved == to_resolved {
+            return Ok(());
+        }
+
+        if source_kind == EntryKind::Directory && to_resolved.starts_with(&from_resolved) {
+            return Err(VfsError::new(Errno::EINVAL));
+        }
+
+        let target = lookup(&to_resolved)?;
+        fs::rename(&from_resolved, &to_resolved).map_err(|err| {
+            // POSIX allows either code when the target directory is non-empty.
+            let err = io_error(&err);
+            if err.errno() == Errno::EEXIST {
+                VfsError::new(Errno::ENOTEMPTY)
+            } else {
+                err
+            }
+        })?;
+
+        if let Some(meta) = target
+            && entry_kind(&meta) == EntryKind::File
+        {
+            release_entry(state, file_key(&meta), meta.len());
+        }
+        Ok(())
+    }
+
+    fn unlink(&self, path: &str) -> VfsResult<()> {
+        let resolved = self.resolve(path)?;
+        if resolved == self.root {
+            return Err(VfsError::new(Errno::EISDIR));
+        }
+
+        let mut state = self.state();
+        let meta = lookup(&resolved)?.ok_or(VfsError::new(Errno::ENOENT))?;
+        match entry_kind(&meta) {
+            EntryKind::File => {}
+            EntryKind::Directory => return Err(VfsError::new(Errno::EISDIR)),
+            EntryKind::Other => return Err(VfsError::new(Errno::ENOENT)),
+        }
+
+        fs::remove_file(&resolved).map_err(|err| io_error(&err))?;
+        release_entry(&mut state, file_key(&meta), meta.len());
+        Ok(())
+    }
+
+    fn rmdir(&self, path: &str) -> VfsResult<()> {
+        let resolved = self.resolve(path)?;
+        if resolved == self.root {
+            return Err(VfsError::new(Errno::EBUSY));
+        }
+
+        let mut state = self.state();
+        match lookup(&resolved)?.as_ref().map(entry_kind) {
+            Some(EntryKind::Directory) => {}
+            Some(EntryKind::File) => return Err(VfsError::new(Errno::ENOTDIR)),
+            Some(EntryKind::Other) | None => return Err(VfsError::new(Errno::ENOENT)),
+        }
+
+        fs::remove_dir(&resolved).map_err(|err| {
+            // POSIX allows either code when the directory is non-empty.
+            let err = io_error(&err);
+            if err.errno() == Errno::EEXIST {
+                VfsError::new(Errno::ENOTEMPTY)
+            } else {
+                err
+            }
+        })?;
+        state.file_count = state.file_count.saturating_sub(1);
+        Ok(())
+    }
+
+    fn open(&self, path: &str, mode: OpenMode) -> VfsResult<FileHandle> {
+        mode.validate()?;
+        let resolved = self.resolve(path)?;
+
+        let mut state = self.state();
+        let existing_len = match lookup(&resolved)? {
+            Some(meta) => match entry_kind(&meta) {
+                EntryKind::Directory => return Err(VfsError::new(Errno::EISDIR)),
+                EntryKind::Other => return Err(VfsError::new(Errno::EACCES)),
+                EntryKind::File if mode.create_new => {
+                    return Err(VfsError::new(Errno::EEXIST));
+                }
+                EntryKind::File => Some(meta.len()),
+            },
+            None if mode.create || mode.create_new => {
+                self.ensure_entry_slot(&state)?;
+                None
+            }
+            None => return Err(VfsError::new(Errno::ENOENT)),
+        };
+        let creating = existing_len.is_none();
+
+        // O_NOFOLLOW keeps a symlink swapped in after the lookup from being
+        // followed; O_NONBLOCK keeps a swapped-in FIFO from blocking the open.
+        // The fstat below then rejects anything that is not a regular file.
+        let file = OpenOptions::new()
+            .read(mode.read)
+            .write(mode.write || creating)
+            .create(creating)
+            .create_new(mode.create_new)
+            .truncate(mode.truncate)
+            .custom_flags(libc::O_NOFOLLOW | libc::O_NONBLOCK)
+            .open(&resolved)
+            .map_err(|err| io_error(&err))?;
+
+        let meta = file.metadata().map_err(|err| io_error(&err))?;
+        if !meta.is_file() {
+            return Err(VfsError::new(Errno::EACCES));
+        }
+
+        if mode.truncate
+            && let Some(old_len) = existing_len
+        {
+            // The open already truncated; usage drops by the previous length.
+            state.used_bytes = state.used_bytes.saturating_sub(old_len);
+        }
+        if creating {
+            state.file_count += 1;
+        }
+
+        let handle = FileHandle::new(state.next_handle);
+        state.next_handle += 1;
+        state
+            .open_files
+            .entry(file_key(&meta))
+            .or_default()
+            .open_handles += 1;
+        state.handles.insert(
+            handle,
+            HandleState {
+                file,
+                key: file_key(&meta),
+                readable: mode.read,
+                writable: mode.write,
+                append: mode.append,
+            },
+        );
+        Ok(handle)
+    }
+
+    fn read_at(&self, handle: FileHandle, offset: u64, buf: &mut [u8]) -> VfsResult<usize> {
+        let state = self.state();
+        let handle = state
+            .handles
+            .get(&handle)
+            .ok_or(VfsError::new(Errno::EBADF))?;
+        if !handle.readable {
+            return Err(VfsError::new(Errno::EBADF));
+        }
+
+        let mut total = 0;
+        while total < buf.len() {
+            let position = offset
+                .checked_add(total as u64)
+                .ok_or(VfsError::new(Errno::EINVAL))?;
+            match handle.file.read_at(&mut buf[total..], position) {
+                Ok(0) => break,
+                Ok(read) => total += read,
+                Err(err) if err.kind() == io::ErrorKind::Interrupted => {}
+                Err(err) => return Err(io_error(&err)),
+            }
+        }
+        Ok(total)
+    }
+
+    fn write_at(&self, handle: FileHandle, offset: u64, data: &[u8]) -> VfsResult<usize> {
+        let mut guard = self.state();
+        let state = &mut *guard;
+        let handle = state
+            .handles
+            .get(&handle)
+            .ok_or(VfsError::new(Errno::EBADF))?;
+        if !handle.writable {
+            return Err(VfsError::new(Errno::EBADF));
+        }
+
+        if data.is_empty() {
+            return Ok(0);
+        }
+
+        let old_len = file_len(&handle.file)?;
+        let write_offset = if handle.append { old_len } else { offset };
+        let write_end = write_offset
+            .checked_add(data.len() as u64)
+            .ok_or(VfsError::new(Errno::EINVAL))?;
+        let new_len = old_len.max(write_end);
+        let used_bytes = self.resized_usage(state.used_bytes, old_len, new_len)?;
+
+        match handle.file.write_all_at(data, write_offset) {
+            Ok(()) => {
+                state.used_bytes = used_bytes;
+                Ok(data.len())
+            }
+            Err(err) => {
+                // Resync usage with whatever the partial write left on disk.
+                let actual_len = file_len(&handle.file).unwrap_or(old_len);
+                state.used_bytes = state
+                    .used_bytes
+                    .saturating_sub(old_len)
+                    .saturating_add(actual_len);
+                Err(io_error(&err))
+            }
+        }
+    }
+
+    fn truncate(&self, handle: FileHandle, len: u64) -> VfsResult<()> {
+        let mut guard = self.state();
+        let state = &mut *guard;
+        let handle = state
+            .handles
+            .get(&handle)
+            .ok_or(VfsError::new(Errno::EBADF))?;
+        if !handle.writable {
+            return Err(VfsError::new(Errno::EINVAL));
+        }
+
+        let old_len = file_len(&handle.file)?;
+        let used_bytes = self.resized_usage(state.used_bytes, old_len, len)?;
+        handle.file.set_len(len).map_err(|err| io_error(&err))?;
+        state.used_bytes = used_bytes;
+        Ok(())
+    }
+
+    fn close(&self, handle: FileHandle) -> VfsResult<()> {
+        let mut guard = self.state();
+        let state = &mut *guard;
+        let handle = state
+            .handles
+            .remove(&handle)
+            .ok_or(VfsError::new(Errno::EBADF))?;
+
+        let Some(open_file) = state.open_files.get_mut(&handle.key) else {
+            return Ok(());
+        };
+        open_file.open_handles -= 1;
+        if open_file.open_handles > 0 {
+            return Ok(());
+        }
+
+        let unlinked = open_file.unlinked;
+        state.open_files.remove(&handle.key);
+        if unlinked {
+            // The last handle to an unlinked file releases its storage.
+            let len = file_len(&handle.file).unwrap_or(0);
+            state.used_bytes = state.used_bytes.saturating_sub(len);
+            state.file_count = state.file_count.saturating_sub(1);
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct State {
+    handles: BTreeMap<FileHandle, HandleState>,
+    open_files: BTreeMap<FileKey, OpenFileState>,
+    next_handle: u64,
+    used_bytes: u64,
+    file_count: u64,
+}
+
+#[derive(Debug)]
+struct HandleState {
+    file: File,
+    key: FileKey,
+    readable: bool,
+    writable: bool,
+    append: bool,
+}
+
+/// Device and inode pair identifying a file across renames and unlinks.
+type FileKey = (u64, u64);
+
+#[derive(Debug, Default)]
+struct OpenFileState {
+    open_handles: u64,
+    unlinked: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EntryKind {
+    File,
+    Directory,
+    Other,
+}
+
+fn entry_kind(meta: &fs::Metadata) -> EntryKind {
+    if meta.is_dir() {
+        EntryKind::Directory
+    } else if meta.is_file() {
+        EntryKind::File
+    } else {
+        EntryKind::Other
+    }
+}
+
+fn metadata_from(meta: &fs::Metadata) -> Option<Metadata> {
+    match entry_kind(meta) {
+        EntryKind::File => Some(Metadata {
+            file_type: FileType::File,
+            len: meta.len(),
+        }),
+        EntryKind::Directory => Some(Metadata {
+            file_type: FileType::Directory,
+            len: 0,
+        }),
+        EntryKind::Other => None,
+    }
+}
+
+/// Stats a path without following symlinks; `None` when it does not exist.
+fn lookup(path: &Path) -> VfsResult<Option<fs::Metadata>> {
+    match fs::symlink_metadata(path) {
+        Ok(meta) => Ok(Some(meta)),
+        Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(None),
+        Err(err) => Err(io_error(&err)),
+    }
+}
+
+fn file_key(meta: &fs::Metadata) -> FileKey {
+    (meta.dev(), meta.ino())
+}
+
+fn file_len(file: &File) -> VfsResult<u64> {
+    file.metadata()
+        .map(|meta| meta.len())
+        .map_err(|err| io_error(&err))
+}
+
+/// Releases a removed directory entry, deferring to the last close while any
+/// handle keeps the file open.
+fn release_entry(state: &mut State, key: FileKey, len: u64) {
+    if let Some(open_file) = state.open_files.get_mut(&key) {
+        open_file.unlinked = true;
+    } else {
+        state.used_bytes = state.used_bytes.saturating_sub(len);
+        state.file_count = state.file_count.saturating_sub(1);
+    }
+}
+
+fn scan_tree(dir: &Path, used_bytes: &mut u64, file_count: &mut u64) -> io::Result<()> {
+    for entry in fs::read_dir(dir)? {
+        let entry = entry?;
+        // DirEntry::metadata does not follow symlinks, so links and special
+        // files fall through unaccounted, matching their invisibility.
+        let meta = entry.metadata()?;
+        if meta.is_dir() {
+            *file_count += 1;
+            scan_tree(&entry.path(), used_bytes, file_count)?;
+        } else if meta.is_file() {
+            *file_count += 1;
+            *used_bytes = used_bytes.saturating_add(meta.len());
+        }
+    }
+    Ok(())
+}
+
+fn io_error(err: &io::Error) -> VfsError {
+    let errno = match err.raw_os_error() {
+        Some(libc::ENOENT) => Errno::ENOENT,
+        Some(libc::ENOTDIR) => Errno::ENOTDIR,
+        Some(libc::EISDIR) => Errno::EISDIR,
+        Some(libc::EEXIST) => Errno::EEXIST,
+        Some(libc::ENOTEMPTY) => Errno::ENOTEMPTY,
+        Some(libc::EACCES | libc::EPERM | libc::ELOOP | libc::EROFS) => Errno::EACCES,
+        Some(libc::ENOSPC | libc::EDQUOT | libc::EFBIG) => Errno::ENOSPC,
+        Some(libc::EBUSY) => Errno::EBUSY,
+        Some(libc::EBADF) => Errno::EBADF,
+        _ => Errno::EINVAL,
+    };
+    VfsError::new(errno)
+}

--- a/src/vfs/local.rs
+++ b/src/vfs/local.rs
@@ -1,6 +1,6 @@
 //! Local-directory VFS that persists sandbox files under a host directory.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs::{self, File, OpenOptions};
 use std::io;
 use std::os::unix::fs::{FileExt, MetadataExt, OpenOptionsExt};
@@ -82,6 +82,52 @@ impl LocalVfs {
             used_bytes: state.used_bytes,
             file_count: state.file_count,
         })
+    }
+
+    /// Rescans the backing directory and replaces quota usage with the
+    /// result, returning the new numbers.
+    ///
+    /// Call this after the host mutates the tree so enforcement runs against
+    /// reality again. Unlinked-but-open files are no longer visible in the
+    /// tree but keep their bytes and entry slot accounted until the last
+    /// handle closes, exactly as live accounting does.
+    pub fn refresh(&self) -> VfsResult<VfsStats> {
+        let mut state = self.state();
+        let mut used_bytes = 0;
+        let mut file_count = 0;
+        scan_tree(&self.root, &mut used_bytes, &mut file_count).map_err(|err| io_error(&err))?;
+
+        let mut counted = BTreeSet::new();
+        for handle in state.handles.values() {
+            let unlinked = state
+                .open_files
+                .get(&handle.key)
+                .is_some_and(|open_file| open_file.unlinked);
+            if unlinked && counted.insert(handle.key) {
+                used_bytes = used_bytes.saturating_add(file_len(&handle.file).unwrap_or(0));
+                file_count += 1;
+            }
+        }
+
+        state.used_bytes = used_bytes;
+        state.file_count = file_count;
+        Ok(VfsStats {
+            used_bytes,
+            file_count,
+        })
+    }
+
+    /// Replaces quota usage with externally computed numbers.
+    ///
+    /// For hosts that track usage out of band instead of trusting the VFS to
+    /// aggregate it. Subsequent operations apply their deltas on top of the
+    /// pushed baseline, and quota enforcement blocks growth against it.
+    /// Numbers above the quota are accepted; they only prevent further
+    /// growth, matching how construction treats oversized existing trees.
+    pub fn set_usage(&self, usage: VfsStats) {
+        let mut state = self.state();
+        state.used_bytes = usage.used_bytes;
+        state.file_count = usage.file_count;
     }
 
     fn state(&self) -> MutexGuard<'_, State> {

--- a/src/vfs/mod.rs
+++ b/src/vfs/mod.rs
@@ -1,6 +1,8 @@
-//! Virtual filesystem traits and the in-memory implementation.
+//! Virtual filesystem traits with in-memory and local-directory implementations.
 
 pub mod conformance;
+#[cfg(unix)]
+pub mod local;
 pub mod mem;
 
 mod path;
@@ -8,6 +10,8 @@ mod path;
 use std::error::Error;
 use std::fmt;
 
+#[cfg(unix)]
+pub use local::LocalVfs;
 pub use mem::{InMemoryVfs, InMemoryVfsSnapshot, VfsQuota, VfsStats};
 
 /// Result type returned by VFS operations.

--- a/tests/vfs_conformance.rs
+++ b/tests/vfs_conformance.rs
@@ -1,6 +1,28 @@
 use tinysandbox::vfs::conformance;
 use tinysandbox::vfs::{InMemoryVfs, VfsQuota};
 
+#[cfg(unix)]
+#[test]
+fn local_vfs_satisfies_public_conformance_suite() {
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    let base = std::env::temp_dir().join(format!(
+        "tinysandbox-local-conformance-{}",
+        std::process::id()
+    ));
+    let _ = std::fs::remove_dir_all(&base);
+    std::fs::create_dir_all(&base).expect("create conformance base dir");
+
+    let counter = AtomicU64::new(0);
+    conformance::run(|quota: VfsQuota| {
+        let root = base.join(counter.fetch_add(1, Ordering::Relaxed).to_string());
+        std::fs::create_dir(&root).expect("create conformance root");
+        tinysandbox::vfs::LocalVfs::with_quota(&root, quota).expect("open local vfs")
+    });
+
+    let _ = std::fs::remove_dir_all(&base);
+}
+
 #[test]
 fn in_memory_vfs_satisfies_public_conformance_suite() {
     conformance::run(|quota: VfsQuota| InMemoryVfs::new(quota));

--- a/tests/vfs_local.rs
+++ b/tests/vfs_local.rs
@@ -1,0 +1,176 @@
+//! Containment, symlink, and persistence tests for the local-directory VFS.
+
+#![cfg(unix)]
+
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use tinysandbox::vfs::{Errno, LocalVfs, OpenMode, Vfs, VfsQuota, VfsResult};
+
+/// Creates a unique empty directory under the system temp dir and returns it
+/// alongside its parent scratch dir (useful for planting escape targets).
+fn scratch_dirs(test: &str) -> (PathBuf, PathBuf) {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let parent = std::env::temp_dir().join(format!(
+        "tinysandbox-local-{test}-{}-{}",
+        std::process::id(),
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    ));
+    let root = parent.join("root");
+    let _ = std::fs::remove_dir_all(&parent);
+    std::fs::create_dir_all(&root).expect("create scratch root");
+    (parent, root)
+}
+
+fn write_file(vfs: &LocalVfs, path: &str, data: &[u8]) -> VfsResult<()> {
+    let handle = vfs.open(path, OpenMode::write_only().create_new())?;
+    vfs.write_at(handle, 0, data)?;
+    vfs.close(handle)
+}
+
+fn read_file(vfs: &LocalVfs, path: &str) -> VfsResult<Vec<u8>> {
+    let len = vfs.stat(path)?.len as usize;
+    let handle = vfs.open(path, OpenMode::read_only())?;
+    let mut buf = vec![0; len];
+    let read = vfs.read_at(handle, 0, &mut buf)?;
+    vfs.close(handle)?;
+    buf.truncate(read);
+    Ok(buf)
+}
+
+fn assert_errno<T>(result: VfsResult<T>, errno: Errno) {
+    match result {
+        Ok(_) => panic!("expected {}, got Ok", errno.name()),
+        Err(err) => assert_eq!(err.errno(), errno),
+    }
+}
+
+#[test]
+fn parent_traversal_is_clamped_at_the_root() {
+    let (parent, root) = scratch_dirs("traversal");
+    std::fs::write(parent.join("secret.txt"), b"top secret").expect("write secret");
+    let vfs = LocalVfs::new(&root).expect("open local vfs");
+
+    // "/../secret.txt" resolves to "/secret.txt" inside the root, not to the
+    // sibling file next to it.
+    assert_errno(vfs.stat("/../secret.txt"), Errno::ENOENT);
+    assert_errno(vfs.stat("/../../../../secret.txt"), Errno::ENOENT);
+    assert_errno(vfs.stat("relative"), Errno::EINVAL);
+    assert_errno(vfs.stat("/\0"), Errno::EINVAL);
+
+    write_file(&vfs, "/../escape.txt", b"contained").expect("write clamped path");
+    assert!(root.join("escape.txt").is_file());
+    assert!(!parent.join("escape.txt").exists());
+
+    let _ = std::fs::remove_dir_all(&parent);
+}
+
+#[test]
+fn symlinks_are_invisible_and_never_followed() {
+    let (parent, root) = scratch_dirs("symlink");
+    std::fs::write(parent.join("secret.txt"), b"top secret").expect("write secret");
+    std::os::unix::fs::symlink(parent.join("secret.txt"), root.join("link"))
+        .expect("plant file symlink");
+    std::os::unix::fs::symlink(&parent, root.join("linkdir")).expect("plant dir symlink");
+    let vfs = LocalVfs::new(&root).expect("open local vfs");
+
+    // Final-component symlink: invisible to stat/unlink, unopenable.
+    assert_errno(vfs.stat("/link"), Errno::ENOENT);
+    assert_errno(vfs.unlink("/link"), Errno::ENOENT);
+    assert_errno(vfs.open("/link", OpenMode::read_only()), Errno::EACCES);
+    assert_errno(
+        vfs.open("/link", OpenMode::write_only().create()),
+        Errno::EACCES,
+    );
+
+    // Intermediate-component symlink: the subtree behind it does not exist.
+    assert_errno(vfs.stat("/linkdir/secret.txt"), Errno::ENOENT);
+    assert_errno(
+        vfs.open("/linkdir/new.txt", OpenMode::write_only().create()),
+        Errno::ENOENT,
+    );
+    assert_errno(vfs.readdir("/linkdir"), Errno::ENOENT);
+
+    // Both symlinks are hidden from directory listings.
+    assert!(vfs.readdir("/").expect("readdir root").is_empty());
+
+    // Renaming a symlink out or a file over one never follows the link.
+    assert_errno(vfs.rename("/link", "/renamed"), Errno::ENOENT);
+    write_file(&vfs, "/plain.txt", b"plain").expect("write plain file");
+    vfs.rename("/plain.txt", "/link")
+        .expect("rename over symlink replaces the link itself");
+
+    let names: Vec<String> = vfs
+        .readdir("/")
+        .expect("readdir root")
+        .into_iter()
+        .map(|entry| entry.name)
+        .collect();
+    assert_eq!(names, ["link"]);
+
+    // The escape target is untouched throughout.
+    let secret = std::fs::read(parent.join("secret.txt")).expect("read secret");
+    assert_eq!(secret, b"top secret");
+    assert_eq!(
+        std::fs::read(root.join("link")).expect("replaced link is a regular file"),
+        b"plain"
+    );
+
+    let _ = std::fs::remove_dir_all(&parent);
+}
+
+#[test]
+fn contents_persist_across_instances_and_seed_quota_usage() {
+    let (parent, root) = scratch_dirs("persist");
+
+    {
+        let vfs = LocalVfs::new(&root).expect("open local vfs");
+        vfs.mkdir("/dir").expect("mkdir");
+        write_file(&vfs, "/dir/data.txt", b"hello disk").expect("write file");
+    }
+
+    assert_eq!(
+        std::fs::read(root.join("dir/data.txt")).expect("file persisted"),
+        b"hello disk"
+    );
+
+    let quota = VfsQuota {
+        max_bytes: 16,
+        max_files: 4,
+        max_file_size: 16,
+    };
+    let vfs = LocalVfs::with_quota(&root, quota).expect("reopen local vfs");
+    assert_eq!(
+        read_file(&vfs, "/dir/data.txt").expect("read back"),
+        b"hello disk"
+    );
+
+    // Usage is seeded from the existing tree: 10 bytes, 1 dir + 1 file.
+    let stats = vfs.stats().expect("stats");
+    assert_eq!(stats.used_bytes, 10);
+    assert_eq!(stats.file_count, 2);
+
+    // The seeded usage feeds quota enforcement for new growth.
+    let handle = vfs
+        .open("/dir/more.txt", OpenMode::write_only().create_new())
+        .expect("open new file");
+    assert_errno(vfs.write_at(handle, 0, b"12345678"), Errno::ENOSPC);
+    vfs.write_at(handle, 0, b"123456")
+        .expect("write within quota");
+    vfs.close(handle).expect("close handle");
+
+    let _ = std::fs::remove_dir_all(&parent);
+}
+
+#[test]
+fn root_must_be_an_existing_directory() {
+    let (parent, root) = scratch_dirs("badroot");
+
+    assert!(LocalVfs::new(parent.join("missing")).is_err());
+
+    let file = root.join("file.txt");
+    std::fs::write(&file, b"x").expect("write file");
+    assert!(LocalVfs::new(&file).is_err());
+
+    let _ = std::fs::remove_dir_all(&parent);
+}

--- a/tests/vfs_local.rs
+++ b/tests/vfs_local.rs
@@ -5,7 +5,7 @@
 use std::path::PathBuf;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use tinysandbox::vfs::{Errno, LocalVfs, OpenMode, Vfs, VfsQuota, VfsResult};
+use tinysandbox::vfs::{Errno, LocalVfs, OpenMode, Vfs, VfsQuota, VfsResult, VfsStats};
 
 /// Creates a unique empty directory under the system temp dir and returns it
 /// alongside its parent scratch dir (useful for planting escape targets).
@@ -158,6 +158,56 @@ fn contents_persist_across_instances_and_seed_quota_usage() {
     vfs.write_at(handle, 0, b"123456")
         .expect("write within quota");
     vfs.close(handle).expect("close handle");
+
+    let _ = std::fs::remove_dir_all(&parent);
+}
+
+#[test]
+fn refresh_and_pushed_usage_rebaseline_quota_accounting() {
+    let (parent, root) = scratch_dirs("refresh");
+    let quota = VfsQuota {
+        max_bytes: 16,
+        max_files: 8,
+        max_file_size: 16,
+    };
+    let vfs = LocalVfs::with_quota(&root, quota).expect("open local vfs");
+    write_file(&vfs, "/a.bin", b"aaaa").expect("write file");
+
+    // External mutation is invisible until a refresh rescans the tree.
+    std::fs::write(root.join("external.bin"), b"bbbbbb").expect("write external file");
+    assert_eq!(vfs.stats().expect("stats").used_bytes, 4);
+    let stats = vfs.refresh().expect("refresh");
+    assert_eq!(stats.used_bytes, 10);
+    assert_eq!(stats.file_count, 2);
+
+    // Unlinked-but-open files keep their bytes and slot across a refresh.
+    let held = vfs.open("/a.bin", OpenMode::read_write()).expect("open");
+    vfs.unlink("/a.bin").expect("unlink open file");
+    let stats = vfs.refresh().expect("refresh with unlinked-open file");
+    assert_eq!(stats.used_bytes, 10);
+    assert_eq!(stats.file_count, 2);
+    vfs.close(held).expect("close releases unlinked storage");
+    let stats = vfs.stats().expect("stats");
+    assert_eq!(stats.used_bytes, 6);
+    assert_eq!(stats.file_count, 1);
+
+    // Pushed usage becomes the enforcement baseline.
+    vfs.set_usage(VfsStats {
+        used_bytes: 16,
+        file_count: 1,
+    });
+    let handle = vfs
+        .open("/b.bin", OpenMode::write_only().create_new())
+        .expect("open new file");
+    assert_errno(vfs.write_at(handle, 0, b"x"), Errno::ENOSPC);
+    vfs.set_usage(VfsStats {
+        used_bytes: 6,
+        file_count: 2,
+    });
+    vfs.write_at(handle, 0, b"x")
+        .expect("write fits the pushed baseline");
+    vfs.close(handle).expect("close handle");
+    assert_eq!(vfs.stats().expect("stats").used_bytes, 7);
 
     let _ = std::fs::remove_dir_all(&parent);
 }

--- a/tinysandbox-node/README.md
+++ b/tinysandbox-node/README.md
@@ -23,7 +23,7 @@ console.log(result.stdout)
 - A bash-like shell subset with pipelines, redirects, variables, and session state.
 - Built-in commands such as `cat`, `grep`, `head`, `tail`, `sort`, `uniq`, `wc`, `sed`, `jq`, `ls`, `cp`, `mv`, `rm`, and `mkdir`.
 - A quota-enforced virtual filesystem with direct host APIs and JavaScript-backed VFS adapters.
-- An optional local directory VFS (`localVfs: { root, quota? }`, Unix only) that persists the sandbox filesystem under a host directory with strict path containment (`..` clamped at the root, symlinks never followed).
+- An optional local directory VFS (`localVfs: { root, quota? }`, Unix only) that persists the sandbox filesystem under a host directory with strict path containment (`..` clamped at the root, symlinks never followed). Quota usage can be rebaselined from the host via `sandbox.refreshLocalVfs()` (rescan) or `sandbox.setLocalVfsUsage({ usedBytes, fileCount })` (push).
 - A sandboxed `js` command with a Node-compatible synchronous `fs` subset, `require`, `Buffer`, `process`, and `console`; expose JS-facing custom host functionality as syscalls.
 - Limits and metrics for wall time, output size, command timings, pipe bytes, jq input bytes, and wasm memory. jq input bytes and JSON nesting are capped before evaluation, and the jq filter program text (not input data) is capped on size, nesting, and syntax complexity; jq filter evaluation has the limitations documented in the repository README.
 

--- a/tinysandbox-node/README.md
+++ b/tinysandbox-node/README.md
@@ -23,6 +23,7 @@ console.log(result.stdout)
 - A bash-like shell subset with pipelines, redirects, variables, and session state.
 - Built-in commands such as `cat`, `grep`, `head`, `tail`, `sort`, `uniq`, `wc`, `sed`, `jq`, `ls`, `cp`, `mv`, `rm`, and `mkdir`.
 - A quota-enforced virtual filesystem with direct host APIs and JavaScript-backed VFS adapters.
+- An optional local directory VFS (`localVfs: { root, quota? }`, Unix only) that persists the sandbox filesystem under a host directory with strict path containment (`..` clamped at the root, symlinks never followed).
 - A sandboxed `js` command with a Node-compatible synchronous `fs` subset, `require`, `Buffer`, `process`, and `console`; expose JS-facing custom host functionality as syscalls.
 - Limits and metrics for wall time, output size, command timings, pipe bytes, jq input bytes, and wasm memory. jq input bytes and JSON nesting are capped before evaluation, and the jq filter program text (not input data) is capped on size, nesting, and syntax complexity; jq filter evaluation has the limitations documented in the repository README.
 

--- a/tinysandbox-node/__test__/local_vfs.test.mjs
+++ b/tinysandbox-node/__test__/local_vfs.test.mjs
@@ -77,6 +77,43 @@ test('localVfs enforces quota and reports stats', { skip: !isUnix }, async () =>
   })
 })
 
+test('localVfs usage can be refreshed and pushed from the host', { skip: !isUnix }, async () => {
+  await withScratchDir(async (root) => {
+    const sandbox = new Sandbox({ localVfs: { root, quota: { maxBytes: 16 } } })
+    await sandbox.fs.writeFile('/a.bin', Buffer.alloc(4, 1))
+
+    // The host mutates the tree behind the sandbox's back...
+    await writeFile(join(root, 'external.bin'), Buffer.alloc(6, 2))
+    let stats = await sandbox.stats()
+    assert.equal(stats.vfs.usedBytes, 4)
+
+    // ...and reconciles with a rescan.
+    const refreshed = await sandbox.refreshLocalVfs()
+    assert.equal(refreshed.usedBytes, 10)
+    assert.equal(refreshed.fileCount, 2)
+    stats = await sandbox.stats()
+    assert.equal(stats.vfs.usedBytes, 10)
+
+    // Pushed usage becomes the enforcement baseline.
+    sandbox.setLocalVfsUsage({ usedBytes: 16, fileCount: 2 })
+    await assert.rejects(
+      () => sandbox.fs.appendFile('/a.bin', Buffer.from('x')),
+      (err) => {
+        assert.equal(err.code, 'ENOSPC')
+        return true
+      }
+    )
+    sandbox.setLocalVfsUsage({ usedBytes: 10, fileCount: 2 })
+    await sandbox.fs.appendFile('/a.bin', Buffer.from('x'))
+
+    assert.throws(() => sandbox.setLocalVfsUsage({ usedBytes: -1, fileCount: 0 }), /usedBytes/)
+
+    const plain = new Sandbox()
+    await assert.rejects(() => plain.refreshLocalVfs(), /localVfs/)
+    assert.throws(() => plain.setLocalVfsUsage({ usedBytes: 0, fileCount: 0 }), /localVfs/)
+  })
+})
+
 test('localVfs rejects invalid configuration', { skip: !isUnix }, async () => {
   await withScratchDir(async (root) => {
     assert.throws(() => new Sandbox({ localVfs: { root: join(root, 'missing') } }), /localVfs root/)

--- a/tinysandbox-node/__test__/local_vfs.test.mjs
+++ b/tinysandbox-node/__test__/local_vfs.test.mjs
@@ -1,0 +1,94 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { mkdir, mkdtemp, readFile, rm, symlink, writeFile } from 'node:fs/promises'
+import { existsSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Sandbox } from '../index.js'
+
+const isUnix = process.platform !== 'win32'
+
+async function withScratchDir(fn) {
+  const parent = await mkdtemp(join(tmpdir(), 'tinysandbox-localvfs-'))
+  const root = join(parent, 'root')
+  await mkdir(root)
+  try {
+    return await fn(root, parent)
+  } finally {
+    await rm(parent, { recursive: true, force: true })
+  }
+}
+
+test('localVfs persists sandbox writes to the host directory', { skip: !isUnix }, async () => {
+  await withScratchDir(async (root) => {
+    await writeFile(join(root, 'seeded.txt'), 'from host')
+    const sandbox = new Sandbox({ localVfs: { root } })
+
+    const seeded = await sandbox.exec('cat /seeded.txt')
+    assert.equal(seeded.exitCode, 0, seeded.stderr)
+    assert.equal(seeded.stdout, 'from host')
+
+    const result = await sandbox.exec('mkdir /work && echo hello > /work/out.txt')
+    assert.equal(result.exitCode, 0, result.stderr)
+    assert.equal(await readFile(join(root, 'work', 'out.txt'), 'utf8'), 'hello\n')
+  })
+})
+
+test('localVfs clamps traversal at the root and refuses symlinks', { skip: !isUnix }, async () => {
+  await withScratchDir(async (root, parent) => {
+    await writeFile(join(parent, 'secret.txt'), 'top secret')
+    await symlink(join(parent, 'secret.txt'), join(root, 'link'))
+    const sandbox = new Sandbox({ localVfs: { root } })
+
+    // "/../secret.txt" resolves inside the root, not to the sibling file.
+    const traversal = await sandbox.exec('cat /../secret.txt')
+    assert.notEqual(traversal.exitCode, 0)
+
+    const escape = await sandbox.exec('echo contained > /../escape.txt')
+    assert.equal(escape.exitCode, 0, escape.stderr)
+    assert.equal(await readFile(join(root, 'escape.txt'), 'utf8'), 'contained\n')
+    assert.ok(!existsSync(join(parent, 'escape.txt')))
+
+    // Symlinks are invisible: unreadable, and writes never follow them.
+    const readLink = await sandbox.exec('cat /link')
+    assert.notEqual(readLink.exitCode, 0)
+    const writeLink = await sandbox.exec('echo clobber > /link')
+    assert.notEqual(writeLink.exitCode, 0)
+    assert.equal(await readFile(join(parent, 'secret.txt'), 'utf8'), 'top secret')
+  })
+})
+
+test('localVfs enforces quota and reports stats', { skip: !isUnix }, async () => {
+  await withScratchDir(async (root) => {
+    const sandbox = new Sandbox({ localVfs: { root, quota: { maxBytes: 8 } } })
+
+    await sandbox.fs.writeFile('/data.bin', Buffer.alloc(8, 1))
+    await assert.rejects(
+      () => sandbox.fs.appendFile('/data.bin', Buffer.from('x')),
+      (err) => {
+        assert.equal(err.code, 'ENOSPC')
+        return true
+      }
+    )
+
+    const stats = await sandbox.stats()
+    assert.equal(stats.vfs.usedBytes, 8)
+    assert.equal(stats.vfs.fileCount, 1)
+  })
+})
+
+test('localVfs rejects invalid configuration', { skip: !isUnix }, async () => {
+  await withScratchDir(async (root) => {
+    assert.throws(() => new Sandbox({ localVfs: { root: join(root, 'missing') } }), /localVfs root/)
+    assert.throws(
+      () => new Sandbox({ localVfs: { root, quota: { maxBytes: -1 } } }),
+      /non-negative safe integer/
+    )
+    const stubVfs = Object.fromEntries(
+      ['stat', 'readdir', 'mkdir', 'rename', 'unlink', 'rmdir', 'open', 'readAt', 'writeAt', 'truncate', 'close'].map(
+        (name) => [name, async () => ({})]
+      )
+    )
+    assert.throws(() => new Sandbox({ vfs: stubVfs, localVfs: { root } }), /either vfs or localVfs/)
+  })
+})

--- a/tinysandbox-node/index.d.ts
+++ b/tinysandbox-node/index.d.ts
@@ -37,7 +37,29 @@ export interface SandboxOptions {
   syscalls?: Record<string, JsSyscall>
   jsPrelude?: string
   fetch?: JsFetch
+  /** Custom VFS implemented in JavaScript. Mutually exclusive with localVfs. */
   vfs?: JsVfs
+  /** Persist the sandbox filesystem under a host directory. Mutually exclusive with vfs. */
+  localVfs?: LocalVfsOptions
+}
+
+/**
+ * Backs the sandbox filesystem with a directory on the host (Unix only).
+ *
+ * Sandbox paths resolve strictly beneath the root: `..` is clamped at the
+ * sandbox root and symlinks are never followed. The directory must exist and
+ * should be dedicated to the sandbox; existing regular files and directories
+ * are visible inside and count toward the quota.
+ */
+export interface LocalVfsOptions {
+  /** Existing host directory that becomes the sandbox root `/`. */
+  root: string
+  /** Storage limits. Unset fields are unlimited. */
+  quota?: {
+    maxBytes?: number
+    maxFiles?: number
+    maxFileSize?: number
+  }
 }
 
 export interface LimitsOptions {

--- a/tinysandbox-node/native.d.ts
+++ b/tinysandbox-node/native.d.ts
@@ -12,6 +12,21 @@ export declare class NativeSandbox {
   exec(script: string): Promise<ExecResult>
   get fs(): SandboxFs
   stats(): Promise<SandboxStats>
+  /**
+   * Rescans the localVfs root directory and replaces quota usage with the
+   * result. Call this after the host mutates the directory outside the
+   * sandbox. Rejects when the sandbox was not built with the localVfs
+   * option.
+   */
+  refreshLocalVfs(): Promise<VfsStatsJs>
+  /**
+   * Replaces localVfs quota usage with externally computed numbers, for
+   * hosts that track usage out of band. Later file operations apply their
+   * deltas on top of the pushed baseline and quota enforcement blocks
+   * growth against it. Throws when the sandbox was not built with the
+   * localVfs option.
+   */
+  setLocalVfsUsage(usage: VfsStatsJs): void
 }
 export type Sandbox = NativeSandbox
 

--- a/tinysandbox-node/src/lib.rs
+++ b/tinysandbox-node/src/lib.rs
@@ -66,6 +66,10 @@ pub struct Sandbox {
     // Napi owns this Arc through the JS object finalizer, so the final drop of
     // JsVfs runtimes stays outside Tokio async contexts.
     inner: Arc<CoreSandbox>,
+    // Concrete handle kept alongside the type-erased one in the sandbox so
+    // refreshLocalVfs/setLocalVfsUsage can reach the LocalVfs-only API.
+    #[cfg(unix)]
+    local_vfs: Option<Arc<tinysandbox::vfs::LocalVfs>>,
 }
 
 #[napi]
@@ -73,6 +77,8 @@ impl Sandbox {
     #[napi(constructor)]
     pub fn new(options: Option<Object<'_>>) -> Result<Self> {
         let mut builder = CoreSandbox::builder();
+        #[cfg(unix)]
+        let mut local_vfs = None;
 
         if let Some(options) = options {
             if let Some(limits) = get_optional_object(&options, "limits")? {
@@ -135,8 +141,18 @@ impl Sandbox {
                 }
                 builder = builder.vfs_arc(Arc::new(JsVfs::new(vfs)?));
             }
-            if let Some(local_vfs) = get_optional_object(&options, "localVfs")? {
-                builder = builder.vfs_arc(build_local_vfs(&local_vfs)?);
+            #[cfg(unix)]
+            if let Some(local_vfs_options) = get_optional_object(&options, "localVfs")? {
+                let vfs = build_local_vfs(&local_vfs_options)?;
+                local_vfs = Some(Arc::clone(&vfs));
+                builder = builder.vfs_arc(vfs);
+            }
+            #[cfg(not(unix))]
+            if options.has_named_property("localVfs")? {
+                return Err(Error::new(
+                    Status::InvalidArg,
+                    "localVfs is only supported on Unix hosts".to_owned(),
+                ));
             }
             if let Some(commands) = get_optional_object(&options, "commands")? {
                 for name in Object::keys(&commands)? {
@@ -159,6 +175,8 @@ impl Sandbox {
 
         Ok(Self {
             inner: Arc::new(builder.build()),
+            #[cfg(unix)]
+            local_vfs,
         })
     }
 
@@ -187,6 +205,65 @@ impl Sandbox {
         .await
         .map_err(|err| Error::new(Status::GenericFailure, err.to_string()))
     }
+
+    /// Rescans the localVfs root directory and replaces quota usage with the
+    /// result. Call this after the host mutates the directory outside the
+    /// sandbox. Rejects when the sandbox was not built with the localVfs
+    /// option.
+    #[napi]
+    pub async fn refresh_local_vfs(&self) -> Result<VfsStatsJs> {
+        #[cfg(unix)]
+        {
+            let vfs = self.local_vfs.clone().ok_or_else(local_vfs_missing)?;
+            tokio::task::spawn_blocking(move || {
+                vfs.refresh()
+                    .map(VfsStatsJs::from)
+                    .map_err(|err| napi_vfs_error(err, None))
+            })
+            .await
+            .map_err(|err| Error::new(Status::GenericFailure, err.to_string()))?
+        }
+        #[cfg(not(unix))]
+        {
+            Err(local_vfs_missing())
+        }
+    }
+
+    /// Replaces localVfs quota usage with externally computed numbers, for
+    /// hosts that track usage out of band. Later file operations apply their
+    /// deltas on top of the pushed baseline and quota enforcement blocks
+    /// growth against it. Throws when the sandbox was not built with the
+    /// localVfs option.
+    #[napi]
+    pub fn set_local_vfs_usage(&self, usage: VfsStatsJs) -> Result<()> {
+        #[cfg(unix)]
+        {
+            let vfs = self.local_vfs.as_ref().ok_or_else(local_vfs_missing)?;
+            let invalid = |field: &str| {
+                Error::new(
+                    Status::InvalidArg,
+                    format!("localVfs usage {field} must be a non-negative safe integer"),
+                )
+            };
+            vfs.set_usage(VfsStats {
+                used_bytes: u64_from_js(usage.used_bytes).map_err(|_| invalid("usedBytes"))?,
+                file_count: u64_from_js(usage.file_count).map_err(|_| invalid("fileCount"))?,
+            });
+            Ok(())
+        }
+        #[cfg(not(unix))]
+        {
+            let _ = usage;
+            Err(local_vfs_missing())
+        }
+    }
+}
+
+fn local_vfs_missing() -> Error {
+    Error::new(
+        Status::GenericFailure,
+        "sandbox was not configured with the localVfs option".to_owned(),
+    )
 }
 
 #[napi]
@@ -1110,7 +1187,7 @@ fn parse_limits(limits: Object<'_>) -> Result<Limits> {
 }
 
 #[cfg(unix)]
-fn build_local_vfs(options: &Object<'_>) -> Result<Arc<dyn Vfs>> {
+fn build_local_vfs(options: &Object<'_>) -> Result<Arc<tinysandbox::vfs::LocalVfs>> {
     let root: String = options.get_named_property("root")?;
     let mut quota = VfsQuota::unlimited();
     if let Some(limits) = get_optional_object(options, "quota")? {
@@ -1138,14 +1215,6 @@ fn quota_value(value: f64, name: &str) -> Result<u64> {
             format!("localVfs quota {name} must be a non-negative safe integer"),
         )
     })
-}
-
-#[cfg(not(unix))]
-fn build_local_vfs(_options: &Object<'_>) -> Result<Arc<dyn Vfs>> {
-    Err(Error::new(
-        Status::InvalidArg,
-        "localVfs is only supported on Unix hosts".to_owned(),
-    ))
 }
 
 fn validate_syscall_name(name: &str) -> Result<()> {

--- a/tinysandbox-node/src/lib.rs
+++ b/tinysandbox-node/src/lib.rs
@@ -127,7 +127,16 @@ impl Sandbox {
                 });
             }
             if let Some(vfs) = get_optional_object(&options, "vfs")? {
+                if options.has_named_property("localVfs")? {
+                    return Err(Error::new(
+                        Status::InvalidArg,
+                        "Sandbox constructor accepts either vfs or localVfs, not both".to_owned(),
+                    ));
+                }
                 builder = builder.vfs_arc(Arc::new(JsVfs::new(vfs)?));
+            }
+            if let Some(local_vfs) = get_optional_object(&options, "localVfs")? {
+                builder = builder.vfs_arc(build_local_vfs(&local_vfs)?);
             }
             if let Some(commands) = get_optional_object(&options, "commands")? {
                 for name in Object::keys(&commands)? {
@@ -1098,6 +1107,45 @@ fn parse_limits(limits: Object<'_>) -> Result<Limits> {
         parsed.fetch_response_bytes = usize_from_number(bytes)?;
     }
     Ok(parsed)
+}
+
+#[cfg(unix)]
+fn build_local_vfs(options: &Object<'_>) -> Result<Arc<dyn Vfs>> {
+    let root: String = options.get_named_property("root")?;
+    let mut quota = VfsQuota::unlimited();
+    if let Some(limits) = get_optional_object(options, "quota")? {
+        if let Some(value) = get_optional::<f64>(&limits, "maxBytes")? {
+            quota.max_bytes = quota_value(value, "maxBytes")?;
+        }
+        if let Some(value) = get_optional::<f64>(&limits, "maxFiles")? {
+            quota.max_files = quota_value(value, "maxFiles")?;
+        }
+        if let Some(value) = get_optional::<f64>(&limits, "maxFileSize")? {
+            quota.max_file_size = quota_value(value, "maxFileSize")?;
+        }
+    }
+
+    let vfs = tinysandbox::vfs::LocalVfs::with_quota(&root, quota)
+        .map_err(|err| Error::new(Status::InvalidArg, format!("localVfs root '{root}': {err}")))?;
+    Ok(Arc::new(vfs))
+}
+
+#[cfg(unix)]
+fn quota_value(value: f64, name: &str) -> Result<u64> {
+    u64_from_js(value).map_err(|_| {
+        Error::new(
+            Status::InvalidArg,
+            format!("localVfs quota {name} must be a non-negative safe integer"),
+        )
+    })
+}
+
+#[cfg(not(unix))]
+fn build_local_vfs(_options: &Object<'_>) -> Result<Arc<dyn Vfs>> {
+    Err(Error::new(
+        Status::InvalidArg,
+        "localVfs is only supported on Unix hosts".to_owned(),
+    ))
 }
 
 fn validate_syscall_name(name: &str) -> Result<()> {


### PR DESCRIPTION
## What

Adds `LocalVfs` (Unix only), a second built-in `Vfs` implementation that roots the sandbox filesystem in a directory on the host disk. Files persist across sandboxes and process restarts, existing content is visible inside, and host tools can read what the agent writes.

Node/TS: `new Sandbox({ localVfs: { root: '/path', quota?: { maxBytes, maxFiles, maxFileSize } } })`, mutually exclusive with the callback `vfs` option.

## Containment

- `..` is clamped at the sandbox root by the existing `normalize_path` before any OS call, so lexical traversal cannot escape.
- Symlinks are never followed: they are invisible to lookups (`ENOENT`), skipped by `readdir`, checked per intermediate component during resolution, and rejected at open time with `O_NOFOLLOW` plus a post-open `fstat` regular-file check (`EACCES`).
- Special files (FIFOs, sockets, devices) are refused; `O_NONBLOCK` guards against a FIFO swapped in between lookup and open.
- The root is canonicalized once at construction and must be an existing directory dedicated to the sandbox; external mutation while live can skew quota numbers but cannot break containment.

## Host-driven quota rebaselining

Usage counters can be re-baselined from outside the sandbox instead of trusting the VFS to aggregate forever:

- `LocalVfs::refresh()` / `sandbox.refreshLocalVfs()` — rescans the root directory and replaces usage with the result (unlinked-but-open files stay accounted until last close).
- `LocalVfs::set_usage(stats)` / `sandbox.setLocalVfsUsage({ usedBytes, fileCount })` — pushes externally computed numbers; live operations apply their deltas on top and the quota just answers "should this write be blocked" against the current baseline.

## Correctness

- Passes the full public VFS conformance suite (`tests/vfs_conformance.rs`), including quota accounting, rename-over-existing, and unlink-while-open handle semantics (deferred release keyed by `(dev, ino)`).
- `tests/vfs_local.rs` covers traversal clamping, symlink refusal (final and intermediate components), persistence across instances, quota seeding from an existing tree, and refresh/push rebaselining.
- `__test__/local_vfs.test.mjs` drives the whole stack from Node: shell writes landing on the host disk, escape attempts, quota `ENOSPC`, stats, refresh/push, and config validation.

All ops serialize under one mutex (same model as `InMemoryVfs`); `is_fast()` stays false so disk I/O runs on blocking worker threads.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014ELRcJnwM3dsfHuxpyrRuC