### PR TITLE
Keep npm publishing OIDC-only [skip release]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,6 @@
 # - CARGO_REGISTRY_TOKEN must allow publishing the tinysandbox crate.
 # - npm trusted publishing must trust this workflow for @tinysandbox/tinysandbox
 #   and its four @tinysandbox/tinysandbox-{platform} native packages.
-# - NPM_TOKEN must be set while bootstrapping new native package names. Remove
-#   it after the first publish and configure trusted publishing for each package.
 # - Branch protection must allow github-actions[bot] to push the release commit to main.
 # - External contributor Actions runs should require maintainer approval before CI runs.
 name: Release
@@ -294,32 +292,6 @@ jobs:
           fi
           node scripts/verify-native-packages.mjs --require-binaries
 
-      - name: Check npm publishing bootstrap
-        env:
-          NPM_TOKEN_AVAILABLE: ${{ secrets.NPM_TOKEN != '' }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        working-directory: tinysandbox-node
-        run: |
-          set -euo pipefail
-          native_packages=(
-            @tinysandbox/tinysandbox-darwin-arm64
-            @tinysandbox/tinysandbox-darwin-x64
-            @tinysandbox/tinysandbox-linux-arm64-gnu
-            @tinysandbox/tinysandbox-linux-x64-gnu
-          )
-          missing_packages=()
-          for package_name in "${native_packages[@]}"; do
-            if ! npm view "${package_name}" name >/dev/null 2>&1; then
-              missing_packages+=("${package_name}")
-            fi
-          done
-          if [ "${#missing_packages[@]}" -gt 0 ] && [ "$NPM_TOKEN_AVAILABLE" != "true" ]; then
-            echo "The following npm packages need an initial token-authenticated publish:" >&2
-            printf '  %s\n' "${missing_packages[@]}" >&2
-            echo "Add an NPM_TOKEN repository secret, rerun this release, then configure trusted publishing and remove the secret." >&2
-            exit 1
-          fi
-
       - name: Publish crate
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
@@ -337,7 +309,6 @@ jobs:
       - name: Publish native and facade npm packages
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         working-directory: tinysandbox-node
         run: |
           set -euo pipefail

--- a/scripts/release-native-artifacts.test.mjs
+++ b/scripts/release-native-artifacts.test.mjs
@@ -77,19 +77,15 @@ test("publish assembly routes the complete artifact set into platform packages",
   assert.match(workflow, /package_dir="tinysandbox-node\/npm\/\$\{target\}"/)
 })
 
-test("release versioning preserves unpublished optional packages and supports bootstrap auth", () => {
+test("release versioning preserves unpublished optional packages and uses OIDC publishing", () => {
   assert.doesNotMatch(
     workflow,
     /npm install --prefix tinysandbox-node --package-lock-only/,
     "release preparation must not resolve versions that have not been published yet"
   )
-  assert.match(workflow, /NPM_TOKEN_AVAILABLE: \$\{\{ secrets\.NPM_TOKEN != '' \}\}/)
-  assert.match(workflow, /NODE_AUTH_TOKEN: \$\{\{ secrets\.NPM_TOKEN \}\}/)
-
-  const bootstrapCheck = workflow.indexOf("- name: Check npm publishing bootstrap")
-  const cratePublish = workflow.indexOf("- name: Publish crate")
-  assert.ok(bootstrapCheck >= 0, "release workflow must check first-publish authentication")
-  assert.ok(bootstrapCheck < cratePublish, "npm bootstrap must be checked before publishing the crate")
+  assert.match(workflow, /id-token: write/)
+  assert.match(workflow, /ACTIONS_ID_TOKEN_REQUEST_URL/)
+  assert.doesNotMatch(workflow, /NPM_TOKEN|NODE_AUTH_TOKEN/)
 })
 
 test("platform packages and optional dependencies stay in lockstep", () => {


### PR DESCRIPTION
## What changed

- Remove the temporary `NPM_TOKEN` bootstrap fallback and package-existence preflight from the release workflow.
- Assert in release tests that npm publishing remains OIDC-only.

## Why

All four platform package names are now public, and their trusted-publisher records have been verified to match the existing `@tinysandbox/tinysandbox` configuration:

- repository: `danthegoodman1/tinysandbox`
- workflow: `release.yml`
- permissions: publish and staged publish

No long-lived npm credential is needed. The `[skip release]` marker preserves the pending `0.4.6` recovery release.

## Validation

- `node --test scripts/release-version.test.mjs scripts/release-native-artifacts.test.mjs`
- release workflow YAML parse
- `git diff --check`
