### PR TITLE
Fix npm 12 release package verification [skip release]

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,9 @@ jobs:
             ${{ runner.os }}-cargo-
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
+      - name: Install release npm CLI
+        run: npm install -g npm@12.0.2
       - name: Check release scripts and native matrix
         run: |
           node --test scripts/release-version.test.mjs scripts/release-native-artifacts.test.mjs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -239,7 +239,7 @@ jobs:
           cache-dependency-path: tinysandbox-node/package-lock.json
 
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@12.0.2
 
       - name: Install Node dependencies
         run: npm ci

--- a/scripts/release-native-artifacts.test.mjs
+++ b/scripts/release-native-artifacts.test.mjs
@@ -2,7 +2,11 @@ import assert from "node:assert/strict"
 import { readFileSync } from "node:fs"
 import { test } from "node:test"
 
-import { nativeTargets, verifyNativePackages } from "./verify-native-packages.mjs"
+import {
+  nativeTargets,
+  parsePackFiles,
+  verifyNativePackages
+} from "./verify-native-packages.mjs"
 
 const workflow = readFileSync(new URL("../.github/workflows/release.yml", import.meta.url), "utf8")
 const ciWorkflow = readFileSync(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8")
@@ -99,6 +103,33 @@ test("platform packages and optional dependencies stay in lockstep", () => {
       new RegExp(`require\\(['\"]@tinysandbox/tinysandbox-${escapeRegExp(target)}`)
     )
   }
+})
+
+test("npm pack metadata supports npm 11 and npm 12 output", () => {
+  const metadata = {
+    files: [
+      { path: "package.json" },
+      { path: "index.js" }
+    ]
+  }
+
+  assert.deepEqual(parsePackFiles(JSON.stringify([metadata])), ["index.js", "package.json"])
+  assert.deepEqual(
+    parsePackFiles(JSON.stringify({ "@tinysandbox/tinysandbox": metadata })),
+    ["index.js", "package.json"]
+  )
+  assert.throws(
+    () => parsePackFiles("[]"),
+    /npm pack returned invalid package metadata/
+  )
+})
+
+test("release checks and publishing use the same pinned npm CLI", () => {
+  const releaseNpm = workflow.match(/npm install -g npm@([^\s]+)/)?.[1]
+  const ciNpm = ciWorkflow.match(/npm install -g npm@([^\s]+)/)?.[1]
+
+  assert.equal(releaseNpm, "12.0.2")
+  assert.equal(ciNpm, releaseNpm)
 })
 
 function escapeRegExp(value) {

--- a/scripts/verify-native-packages.mjs
+++ b/scripts/verify-native-packages.mjs
@@ -94,7 +94,23 @@ function packFiles(packageDir) {
     }
   })
   assert.equal(result.status, 0, result.stderr)
-  return JSON.parse(result.stdout)[0].files.map(({ path }) => path).sort()
+  return parsePackFiles(result.stdout)
+}
+
+export function parsePackFiles(stdout) {
+  const parsed = JSON.parse(stdout)
+  const entries = Array.isArray(parsed)
+    ? parsed
+    : parsed && Array.isArray(parsed.files)
+      ? [parsed]
+      : Object.values(parsed ?? {})
+  assert.equal(entries.length, 1, `npm pack returned invalid package metadata: ${stdout}`)
+  const metadata = entries[0]
+  assert.ok(
+    metadata && Array.isArray(metadata.files),
+    `npm pack returned invalid package metadata: ${stdout}`
+  )
+  return metadata.files.map(({ path }) => path).sort()
 }
 
 if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {


### PR DESCRIPTION
## Summary

- support both npm 11 array-form and npm 12 package-keyed `npm pack --json` metadata
- pin the publishing CLI to npm 12.0.2
- run the release-script CI gate with the same Node 24/npm 12.0.2 toolchain used to publish

## Root cause

Release run [31202953836](https://github.com/danthegoodman1/tinysandbox/actions/runs/31202953836) assembled all four native artifacts, then failed before publishing. npm 12 changed `npm pack --dry-run --json` from an array of package metadata to an object keyed by package name, while the verifier unconditionally read element zero.

## Impact

The verifier now accepts the npm 11 and npm 12 formats and fails with the original metadata when neither format is valid. Pinning and CI parity keep the release toolchain deterministic and make this failure reproducible before merge.

## Validation

- `node --test scripts/release-native-artifacts.test.mjs scripts/release-version.test.mjs`
- `node scripts/verify-native-packages.mjs`
- exact npm 12.0.2 `npm pack --dry-run --json` reproduction parsed successfully
- `git diff --check`
