### PR TITLE
Fix npm 12 local publish path [skip release]

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -325,7 +325,7 @@ jobs:
             if npm view "${package_name}@${VERSION}" version >/dev/null 2>&1; then
               echo "${package_name} ${VERSION} is already published"
             else
-              npm publish "${package_dir}" --access public
+              npm publish "./${package_dir}" --access public
             fi
           done
 

--- a/scripts/release-native-artifacts.test.mjs
+++ b/scripts/release-native-artifacts.test.mjs
@@ -132,6 +132,11 @@ test("release checks and publishing use the same pinned npm CLI", () => {
   assert.equal(ciNpm, releaseNpm)
 })
 
+test("npm publishes native packages from explicit local paths", () => {
+  assert.match(workflow, /npm publish "\.\/\$\{package_dir\}" --access public/)
+  assert.doesNotMatch(workflow, /npm publish "\$\{package_dir\}" --access public/)
+})
+
 function escapeRegExp(value) {
   return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
 }


### PR DESCRIPTION
## Summary

- publish native npm packages using explicit `./npm/<target>` local paths
- add a regression assertion that rejects ambiguous package-spec paths

## Root cause

Release run [31206491072](https://github.com/danthegoodman1/tinysandbox/actions/runs/31206491072) assembled and verified all four native packages, then npm 12 interpreted `npm/darwin-arm64` as the GitHub shorthand `github:npm/darwin-arm64`. It failed with `EALLOWGIT` before publishing any npm package.

## Impact

The explicit `./` prefix makes npm 12 publish each generated platform directory as a local package. The preceding crate publication succeeded, and the existing release logic will skip that already-published crate on retry.

## Validation

- npm 12.0.2 `publish --dry-run ./npm/darwin-arm64 --access public`
- `node --test scripts/release-native-artifacts.test.mjs scripts/release-version.test.mjs`
- `git diff --check`
