### PR TITLE
Support Linux hosts with glibc 2.34

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
           cache: npm
           cache-dependency-path: tinysandbox-node/package-lock.json
       - name: Install pinned npm CLI
-        run: npm install -g npm@12.0.2
+        run: npm install -g npm@11.12.1
       - run: npm ci
         working-directory: tinysandbox-node
       - name: Test Rust and Node against loopback S3-compatible API
@@ -107,7 +107,7 @@ jobs:
           cache: npm
           cache-dependency-path: tinysandbox-node/package-lock.json
       - name: Install pinned npm CLI
-        run: npm install -g npm@12.0.2
+        run: npm install -g npm@11.12.1
       - run: npm ci
         working-directory: tinysandbox-node
       - name: Verify GLIBC build environment
@@ -149,7 +149,7 @@ jobs:
           cache: npm
           cache-dependency-path: tinysandbox-node/package-lock.json
       - name: Install pinned npm CLI
-        run: npm install -g npm@12.0.2
+        run: npm install -g npm@11.12.1
       - run: npm ci
         working-directory: tinysandbox-node
       - run: npm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: npm install -g npm@12.0.2
       - name: Check release scripts and native matrix
         run: |
-          node --test scripts/release-version.test.mjs scripts/release-native-artifacts.test.mjs
+          node --test scripts/release-version.test.mjs scripts/release-native-artifacts.test.mjs scripts/verify-glibc-baseline.test.mjs
           node scripts/release-version.mjs check "$(node scripts/release-version.mjs next --bump current)"
       - run: cargo fmt --all --check
       - run: cargo test --workspace --all-features --locked
@@ -64,16 +64,69 @@ jobs:
           node-version: 20
           cache: npm
           cache-dependency-path: tinysandbox-node/package-lock.json
+      - name: Install pinned npm CLI
+        run: npm install -g npm@12.0.2
       - run: npm ci
         working-directory: tinysandbox-node
       - name: Test Rust and Node against loopback S3-compatible API
         run: scripts/test-s3-compat.sh
 
-  node:
+  node-linux:
+    name: node (${{ matrix.os }})
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-26.04, ubuntu-26.04-arm, macos-26-intel, macos-26]
+        include:
+          - os: ubuntu-26.04
+            container_image: quay.io/pypa/manylinux_2_34_x86_64@sha256:249cdcdcd91ba0639b50140a5a4cd09eead2056e2f76267e7919678a66f9d33d
+            binding: tinysandbox-node.linux-x64-gnu.node
+          - os: ubuntu-26.04-arm
+            container_image: quay.io/pypa/manylinux_2_34_aarch64@sha256:8621bc7caecfd1e7818a800e8ae8c979936665f180a93e13efeed54cbb026d74
+            binding: tinysandbox-node.linux-arm64-gnu.node
+    runs-on: ${{ matrix.os }}
+    container:
+      image: ${{ matrix.container_image }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-node-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'tinysandbox-node/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-cargo-node-
+            ${{ runner.os }}-cargo-
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: tinysandbox-node/package-lock.json
+      - name: Install pinned npm CLI
+        run: npm install -g npm@12.0.2
+      - run: npm ci
+        working-directory: tinysandbox-node
+      - name: Verify GLIBC build environment
+        run: test "$(getconf GNU_LIBC_VERSION)" = "glibc 2.34"
+      - run: npm test
+        working-directory: tinysandbox-node
+      - name: Verify native GLIBC baseline
+        run: node scripts/verify-glibc-baseline.mjs "tinysandbox-node/${{ matrix.binding }}" 2.34
+      - run: npm run examples
+        working-directory: tinysandbox-node
+      - run: npm pack --dry-run
+        working-directory: tinysandbox-node
+
+  node-macos:
+    name: node (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-26-intel, macos-26]
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -95,6 +148,8 @@ jobs:
           node-version: 20
           cache: npm
           cache-dependency-path: tinysandbox-node/package-lock.json
+      - name: Install pinned npm CLI
+        run: npm install -g npm@12.0.2
       - run: npm ci
         working-directory: tinysandbox-node
       - run: npm test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -124,7 +124,7 @@ jobs:
         id: release_ref
         run: echo "sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
 
-  build-native:
+  build-linux-native:
     needs: prepare
     if: needs.prepare.outputs.release == 'true'
     strategy:
@@ -135,10 +135,92 @@ jobs:
             artifact: linux-x64-gnu
             uname_arch: x86_64
             binding: tinysandbox-node.linux-x64-gnu.node
+            container_image: quay.io/pypa/manylinux_2_34_x86_64@sha256:249cdcdcd91ba0639b50140a5a4cd09eead2056e2f76267e7919678a66f9d33d
           - os: ubuntu-26.04-arm
             artifact: linux-arm64-gnu
             uname_arch: aarch64
             binding: tinysandbox-node.linux-arm64-gnu.node
+            container_image: quay.io/pypa/manylinux_2_34_aarch64@sha256:8621bc7caecfd1e7818a800e8ae8c979936665f180a93e13efeed54cbb026d74
+    runs-on: ${{ matrix.os }}
+    container:
+      image: ${{ matrix.container_image }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.prepare.outputs.sha }}
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-native-${{ matrix.artifact }}-${{ hashFiles('Cargo.lock', 'Cargo.toml', 'tinysandbox-node/Cargo.toml') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-native-${{ matrix.artifact }}-
+            ${{ runner.os }}-cargo-
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: tinysandbox-node/package-lock.json
+
+      - name: Install pinned npm CLI
+        run: npm install -g npm@12.0.2
+
+      - name: Install Node dependencies
+        run: npm ci
+        working-directory: tinysandbox-node
+
+      - name: Verify GLIBC build environment
+        run: test "$(getconf GNU_LIBC_VERSION)" = "glibc 2.34"
+
+      - name: Build native binding
+        run: npm run build
+        working-directory: tinysandbox-node
+
+      - name: Verify native GLIBC baseline
+        run: node scripts/verify-glibc-baseline.mjs "tinysandbox-node/${{ matrix.binding }}" 2.34
+
+      - name: Load native binding on GLIBC 2.34
+        run: |
+          node -e "const binding = require('./tinysandbox-node/${{ matrix.binding }}'); if (typeof binding.NativeSandbox !== 'function') throw new Error('NativeSandbox export missing')"
+
+      - name: Collect native binding
+        run: |
+          set -euo pipefail
+          actual_arch="$(uname -m)"
+          if [ "$actual_arch" != "${{ matrix.uname_arch }}" ]; then
+            echo "expected ${{ matrix.uname_arch }} runner, got ${actual_arch}" >&2
+            exit 1
+          fi
+          binding="tinysandbox-node/${{ matrix.binding }}"
+          if [ ! -f "$binding" ]; then
+            echo "expected native binding ${binding}" >&2
+            find tinysandbox-node -maxdepth 1 -name '*.node' -print >&2
+            exit 1
+          fi
+          mkdir native-artifact
+          cp "$binding" native-artifact/
+          ls -lh native-artifact
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: native-${{ matrix.artifact }}
+          path: native-artifact/*.node
+          if-no-files-found: error
+
+  build-macos-native:
+    needs: prepare
+    if: needs.prepare.outputs.release == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
           - os: macos-26-intel
             artifact: macos-x64
             uname_arch: x86_64
@@ -173,6 +255,9 @@ jobs:
           cache: npm
           cache-dependency-path: tinysandbox-node/package-lock.json
 
+      - name: Install pinned npm CLI
+        run: npm install -g npm@12.0.2
+
       - name: Install Node dependencies
         run: npm ci
         working-directory: tinysandbox-node
@@ -180,6 +265,10 @@ jobs:
       - name: Build native binding
         run: npm run build
         working-directory: tinysandbox-node
+
+      - name: Load native binding
+        run: |
+          node -e "const binding = require('./tinysandbox-node/${{ matrix.binding }}'); if (typeof binding.NativeSandbox !== 'function') throw new Error('NativeSandbox export missing')"
 
       - name: Collect native binding
         run: |
@@ -208,7 +297,8 @@ jobs:
   publish:
     needs:
       - prepare
-      - build-native
+      - build-linux-native
+      - build-macos-native
     if: needs.prepare.outputs.release == 'true'
     runs-on: ubuntu-26.04
     steps:

--- a/scripts/release-native-artifacts.test.mjs
+++ b/scripts/release-native-artifacts.test.mjs
@@ -42,6 +42,17 @@ const expectedBuilds = [
   }
 ]
 
+const linuxContainers = new Map([
+  [
+    "ubuntu-26.04",
+    "quay.io/pypa/manylinux_2_34_x86_64@sha256:249cdcdcd91ba0639b50140a5a4cd09eead2056e2f76267e7919678a66f9d33d"
+  ],
+  [
+    "ubuntu-26.04-arm",
+    "quay.io/pypa/manylinux_2_34_aarch64@sha256:8621bc7caecfd1e7818a800e8ae8c979936665f180a93e13efeed54cbb026d74"
+  ]
+])
+
 test("release matrix builds the four supported native bindings", () => {
   const matrixEntries = [...workflow.matchAll(
     /- os: ([^\n]+)\n\s+artifact: ([^\n]+)\n\s+uname_arch: ([^\n]+)\n\s+binding: ([^\n]+)/g
@@ -57,13 +68,38 @@ test("release matrix builds the four supported native bindings", () => {
   assert.match(workflow, /matrix\.uname_arch/)
   assert.match(workflow, /cargo-native-\$\{\{ matrix\.artifact \}\}/)
 
-  const nodeMatrix = ciWorkflow.match(/\n  node:\n[\s\S]*?\n        os: \[([^\]]+)\]/)
-  assert.ok(nodeMatrix, "CI must define the Node OS/architecture matrix")
+  const macosNodeMatrix = ciWorkflow.match(/\n  node-macos:\n[\s\S]*?\n        os: \[([^\]]+)\]/)
+  assert.ok(macosNodeMatrix, "CI must define the macOS Node architecture matrix")
   assert.deepEqual(
-    nodeMatrix[1].split(",").map((value) => value.trim()),
-    expectedBuilds.map(({ os }) => os)
+    macosNodeMatrix[1].split(",").map((value) => value.trim()),
+    expectedBuilds.filter(({ os }) => os.startsWith("macos")).map(({ os }) => os)
   )
   assert.match(ciWorkflow, /runner\.arch.*cargo-node/)
+})
+
+test("Linux release and CI builds use pinned GLIBC 2.34 containers", () => {
+  assert.match(workflow, /\n  build-linux-native:/)
+  assert.match(workflow, /\n  build-macos-native:/)
+  assert.match(workflow, /- build-linux-native\n\s+- build-macos-native/)
+  assert.match(ciWorkflow, /\n  node-linux:/)
+
+  for (const [os, image] of linuxContainers) {
+    const escapedImage = escapeRegExp(image)
+    const releaseEntry = new RegExp(
+      `- os: ${escapeRegExp(os)}[\\s\\S]*?container_image: ${escapedImage}`
+    )
+    const ciEntry = new RegExp(
+      `- os: ${escapeRegExp(os)}[\\s\\S]*?container_image: ${escapedImage}`
+    )
+    assert.match(workflow, releaseEntry)
+    assert.match(ciWorkflow, ciEntry)
+  }
+
+  for (const source of [workflow, ciWorkflow]) {
+    assert.match(source, /getconf GNU_LIBC_VERSION/)
+    assert.match(source, /verify-glibc-baseline\.mjs[^\n]*2\.34/)
+  }
+  assert.match(workflow, /Load native binding on GLIBC 2\.34/)
 })
 
 test("publish assembly routes the complete artifact set into platform packages", () => {
@@ -130,6 +166,8 @@ test("release checks and publishing use the same pinned npm CLI", () => {
 
   assert.equal(releaseNpm, "12.0.2")
   assert.equal(ciNpm, releaseNpm)
+  assert.equal([...workflow.matchAll(/npm install -g npm@12\.0\.2/g)].length, 3)
+  assert.equal([...ciWorkflow.matchAll(/npm install -g npm@12\.0\.2/g)].length, 4)
 })
 
 test("npm publishes native packages from explicit local paths", () => {

--- a/scripts/release-native-artifacts.test.mjs
+++ b/scripts/release-native-artifacts.test.mjs
@@ -160,14 +160,10 @@ test("npm pack metadata supports npm 11 and npm 12 output", () => {
   )
 })
 
-test("release checks and publishing use the same pinned npm CLI", () => {
-  const releaseNpm = workflow.match(/npm install -g npm@([^\s]+)/)?.[1]
-  const ciNpm = ciWorkflow.match(/npm install -g npm@([^\s]+)/)?.[1]
-
-  assert.equal(releaseNpm, "12.0.2")
-  assert.equal(ciNpm, releaseNpm)
+test("workflows pin npm CLIs compatible with their Node versions", () => {
   assert.equal([...workflow.matchAll(/npm install -g npm@12\.0\.2/g)].length, 3)
-  assert.equal([...ciWorkflow.matchAll(/npm install -g npm@12\.0\.2/g)].length, 4)
+  assert.equal([...ciWorkflow.matchAll(/npm install -g npm@12\.0\.2/g)].length, 1)
+  assert.equal([...ciWorkflow.matchAll(/npm install -g npm@11\.12\.1/g)].length, 3)
 })
 
 test("npm publishes native packages from explicit local paths", () => {

--- a/scripts/verify-glibc-baseline.mjs
+++ b/scripts/verify-glibc-baseline.mjs
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+import { execFileSync } from "node:child_process"
+import { fileURLToPath } from "node:url"
+
+const DEFAULT_BASELINE = "2.34"
+
+export function parseGlibcVersions(output) {
+  return [...new Set(
+    [...output.matchAll(/GLIBC_(\d+(?:\.\d+)+)/g)]
+      .map((match) => match[1])
+  )].sort(compareVersions)
+}
+
+export function verifyGlibcBaseline(output, baseline = DEFAULT_BASELINE) {
+  const versions = parseGlibcVersions(output)
+  if (versions.length === 0) {
+    throw new Error("ELF metadata did not contain any GLIBC symbol versions")
+  }
+
+  const unsupported = versions.filter((version) => compareVersions(version, baseline) > 0)
+  if (unsupported.length > 0) {
+    throw new Error(
+      `requires GLIBC_${unsupported.at(-1)}, newer than the supported GLIBC_${baseline} baseline`
+    )
+  }
+
+  return versions.at(-1)
+}
+
+function compareVersions(left, right) {
+  const leftParts = left.split(".").map(Number)
+  const rightParts = right.split(".").map(Number)
+  const length = Math.max(leftParts.length, rightParts.length)
+  for (let index = 0; index < length; index += 1) {
+    const difference = (leftParts[index] ?? 0) - (rightParts[index] ?? 0)
+    if (difference !== 0) return difference
+  }
+  return 0
+}
+
+function main() {
+  const [binary, baseline = DEFAULT_BASELINE] = process.argv.slice(2)
+  if (!binary) {
+    throw new Error("usage: verify-glibc-baseline.mjs <ELF binary> [maximum GLIBC version]")
+  }
+
+  const readelf = process.env.READELF || "readelf"
+  const output = execFileSync(readelf, ["--version-info", "--wide", binary], {
+    encoding: "utf8"
+  })
+  const highest = verifyGlibcBaseline(output, baseline)
+  console.log(`${binary}: highest required GLIBC symbol is GLIBC_${highest} (baseline GLIBC_${baseline})`)
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  main()
+}

--- a/scripts/verify-glibc-baseline.test.mjs
+++ b/scripts/verify-glibc-baseline.test.mjs
@@ -1,0 +1,39 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+
+import {
+  parseGlibcVersions,
+  verifyGlibcBaseline
+} from "./verify-glibc-baseline.mjs"
+
+const versionInfo = `
+  004:   2 (GLIBC_2.2.5)   3 (GLIBC_2.34)   4 (GLIBC_2.17)
+  0x0010: Name: GLIBC_2.28 Flags: none Version: 5
+  0x0020: Name: GLIBC_2.34 Flags: none Version: 3
+`
+
+test("parses, deduplicates, and sorts GLIBC symbol versions", () => {
+  assert.deepEqual(
+    parseGlibcVersions(versionInfo),
+    ["2.2.5", "2.17", "2.28", "2.34"]
+  )
+})
+
+test("accepts binaries at or below the configured baseline", () => {
+  assert.equal(verifyGlibcBaseline(versionInfo, "2.34"), "2.34")
+  assert.equal(verifyGlibcBaseline(versionInfo, "3.0"), "2.34")
+})
+
+test("rejects binaries requiring newer GLIBC symbols", () => {
+  assert.throws(
+    () => verifyGlibcBaseline(`${versionInfo}\nGLIBC_2.39`, "2.34"),
+    /requires GLIBC_2\.39, newer than the supported GLIBC_2\.34 baseline/
+  )
+})
+
+test("rejects inputs that are not GLIBC-linked ELF metadata", () => {
+  assert.throws(
+    () => verifyGlibcBaseline("no version information found", "2.34"),
+    /did not contain any GLIBC symbol versions/
+  )
+})

--- a/tinysandbox-node/README.md
+++ b/tinysandbox-node/README.md
@@ -79,11 +79,13 @@ desktop/server platforms:
 | Linux (glibc) | yes | yes |
 | macOS | yes | yes |
 
-CI tests each OS/architecture pair on a native runner. It also bundles the main
-entry point with esbuild and verifies that the resulting application loads only
-the auto-detected native package. The release workflow refuses to publish unless
-all four architecture-specific packages are complete, but the main npm tarball
-is rejected if it contains any `.node` file. Alpine and other musl-based Linux
+Linux prebuilt bindings require glibc 2.34 or newer. CI tests each
+OS/architecture pair on a native runner, with Linux builds and tests running in
+pinned glibc 2.34 containers. It also bundles the main entry point with esbuild
+and verifies that the resulting application loads only the auto-detected native
+package. The release workflow refuses to publish unless all four
+architecture-specific packages are complete, but the main npm tarball is
+rejected if it contains any `.node` file. Alpine and other musl-based Linux
 distributions are not currently included.
 
 ## More

--- a/tinysandbox-node/package-lock.json
+++ b/tinysandbox-node/package-lock.json
@@ -2053,6 +2053,76 @@
         "@octokit/openapi-types": "^27.0.0"
       }
     },
+    "node_modules/@tinysandbox/tinysandbox-darwin-arm64": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@tinysandbox/tinysandbox-darwin-arm64/-/tinysandbox-darwin-arm64-0.4.6.tgz",
+      "integrity": "sha512-lUTvvUvX85WcYzRIP4ZGRVkdMqVFUF7p5cLwgUFKQsO09Ll75gx6g+NnbKU2FZgWTLxEWhGQX3wD19CnDbwy5g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@tinysandbox/tinysandbox-darwin-x64": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@tinysandbox/tinysandbox-darwin-x64/-/tinysandbox-darwin-x64-0.4.6.tgz",
+      "integrity": "sha512-lTOuEe8MP95MSWSN5UO8QKe0ABKiS1KZtZy8TEENPuNEaAV5RDeDn1w/0i/ZRTeSLUacYrgivVfDY/okyuTKnw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@tinysandbox/tinysandbox-linux-arm64-gnu": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@tinysandbox/tinysandbox-linux-arm64-gnu/-/tinysandbox-linux-arm64-gnu-0.4.6.tgz",
+      "integrity": "sha512-ARnoCvSmil/SLjxbDCcpwhTVXTGYTvICUA/p4OfXvgkY31WtwK/LqFHWPKrsI2D1ufUETJcvQXI+DaShMIcY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@tinysandbox/tinysandbox-linux-x64-gnu": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@tinysandbox/tinysandbox-linux-x64-gnu/-/tinysandbox-linux-x64-gnu-0.4.6.tgz",
+      "integrity": "sha512-cds4AW3EJqJ0NbQKSzPatiiOQmgWeUpjj43MRKxWUkzkjyqyE3iduZVgoiFzHUWBoWW9CU4DvpzYve08KX5J3A==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
@@ -2431,18 +2501,6 @@
       "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/@tinysandbox/tinysandbox-darwin-arm64": {
-      "optional": true
-    },
-    "node_modules/@tinysandbox/tinysandbox-darwin-x64": {
-      "optional": true
-    },
-    "node_modules/@tinysandbox/tinysandbox-linux-arm64-gnu": {
-      "optional": true
-    },
-    "node_modules/@tinysandbox/tinysandbox-linux-x64-gnu": {
-      "optional": true
     }
   }
 }


### PR DESCRIPTION
## What changed

- Build and test Linux x64 and ARM64 bindings inside digest-pinned `manylinux_2_34` containers.
- Reject release artifacts that reference GLIBC symbols newer than 2.34.
- Load each release binding inside its glibc 2.34 build container before artifact upload.
- Keep macOS builds native while preserving the existing four-package artifact set.
- Document the glibc 2.34 runtime floor.
- Refresh the now-published native optional dependencies in the npm lockfile and pin Node-compatible npm CLIs: npm 11 on Node 20 and npm 12 on Node 24.

## Why

The Linux native packages were linked directly on Ubuntu 26.04. Their ELF metadata consequently referenced `pidfd_spawnp@GLIBC_2.39`, `pidfd_getpid@GLIBC_2.39`, and C23 parsing symbols from GLIBC 2.38, even though the addon does not require those APIs for its functionality. Building against a controlled glibc 2.34 environment lowers the runtime floor without changing Rust optimization settings or the supported Node versions.

## Validation

- Full Node suite in the pinned ARM64 glibc 2.34 image: 47 tests, 42 passed and 5 live-S3 tests skipped.
- Generated ARM64 binding: highest required symbol is `GLIBC_2.34`; binding loads successfully on glibc 2.34.
- Full local macOS Node suite: 47 tests, 42 passed and 5 live-S3 tests skipped.
- Release/version/verifier unit suite: 19 passed.
- A clean install passed with the CI's exact Node 20.20.2/npm 11.12.1 pairing; npm 10 and npm 12 lockfile checks also passed.
- `npm pack --dry-run`, YAML parsing, `git diff --check`, and actionlint passed.
