### PR TITLE
Add static filesystem mounts

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -5,7 +5,7 @@
 Build `tinysandbox`: a Rust crate providing an ultra-minimal, Linux-like agent
 sandbox — a VFS behind a trait, a bash-compatible shell subset, native
 coreutils builtins, and a Wasmtime-hosted QuickJS runtime — that other Rust
-projects embed via `Sandbox::builder().vfs(...).command(...).build()`. Built-in
+projects embed via `Sandbox::builder().mount("workspace", ...).command(...).build()`. Built-in
 VFS choices include memory, a local directory, and a prefix-rooted read-only S3
 view. Node.js bindings (napi-rs) expose the same sandbox and built-in backends,
 including custom JS-implemented VFS backends.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ use tinysandbox::sandbox::Sandbox;
 async fn main() {
     let sandbox = Sandbox::builder().build();
 
-    sandbox.exec("mkdir /workspace").await;
     sandbox
         .exec("echo 'hello from the sandbox' > /workspace/greeting.txt")
         .await;
@@ -38,7 +37,6 @@ import { Sandbox } from '@tinysandbox/tinysandbox'
 
 const sandbox = new Sandbox()
 
-await sandbox.exec('mkdir /workspace')
 await sandbox.exec("echo 'hello from the sandbox' > /workspace/greeting.txt")
 
 const result = await sandbox.exec('cat /workspace/greeting.txt | grep -c sandbox')
@@ -66,6 +64,7 @@ console.assert(result.stdout === '1\n')
   - [JavaScript prelude](#javascript-prelude)
   - [Fetch](#fetch)
 - [Filesystem backends](#filesystem-backends)
+- [Filesystem mounts](#filesystem-mounts)
 - [Local directory VFS](#local-directory-vfs)
   - [Rust](#rust-5)
   - [TypeScript](#typescript-5)
@@ -203,7 +202,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 import { Sandbox } from '@tinysandbox/tinysandbox'
 
 const sandbox = new Sandbox()
-await sandbox.fs.mkdir('/workspace')
 await sandbox.fs.writeFile('/workspace/report.txt', Buffer.from('direct host access'))
 ```
 
@@ -590,10 +588,51 @@ console.assert(result.stdout === 'echo https://example.test/echo hi\n')
 | `LocalVfs` | Contained host directory | Read/write | Unix |
 | `S3Vfs` | Bucket/key prefix | Read-only | Cargo feature `s3`; included in Node |
 
+## Filesystem mounts
+
+The sandbox root is a read-only mount namespace. Backends are attached at
+static, top-level names such as `/workspace`, `/input`, and `/output`. `/bin`
+is reserved for the synthesized command registry. `ls /` lists both `bin` and
+the configured mounts. Paths outside a mount return `ENOENT`, mount points
+cannot be removed or renamed, and cross-mount renames fail with `EXDEV`.
+Copying between mounts works normally.
+
+By default, a sandbox has one in-memory `workspace` mount and starts with
+`cwd=/workspace`. Rust callers can add or replace mounts through the builder:
+
+```rust ignore
+let sandbox = Sandbox::builder()
+    .mount("workspace", LocalVfs::new("/srv/job/workspace")?)
+    .mount("input", S3Vfs::new(client, "agent-inputs", Some("job-42"))?)
+    .cwd("/workspace")
+    .build();
+```
+
+`clear_mounts()` removes the default workspace and resets the builder cwd to
+`/`. Mount names must be single path components and cannot be `.`, `..`, or
+`bin`. Mounts are fixed after `build()`.
+
+In TypeScript, providing `mounts` replaces the default workspace exactly:
+
+```ts
+const sandbox = new Sandbox({
+  mounts: {
+    workspace: { type: 'memory', quota: { maxBytes: 64 * 1024 * 1024 } },
+    input: { type: 's3', bucket: 'agent-inputs', prefix: 'job-42' },
+    output: { type: 'local', root: '/srv/job/output' }
+  },
+  cwd: '/workspace'
+})
+```
+
+Each mount enforces its own quota. `Sandbox::stats()` reports the checked sum
+of mounts that expose usage statistics. Mounts such as `S3Vfs` that do not
+report usage are skipped.
+
 ## Local directory VFS
 
-On Unix hosts a second built-in filesystem, `LocalVfs`, roots the sandbox in
-a directory on the host disk. Files persist across sandboxes and process
+On Unix hosts, `LocalVfs` roots one mount in a directory on the host disk.
+Files persist across sandboxes and process
 restarts, existing content in the directory is visible inside, and host
 tools can read what the agent writes.
 
@@ -611,8 +650,8 @@ entirely — rebaseline the counters from outside the sandbox: `refresh()`
 rescans the directory, and `set_usage()` pushes externally computed numbers.
 Enforcement then just answers "should this write be blocked" against the
 current baseline, with live operations applying their deltas on top. From
-TypeScript: `await sandbox.refreshLocalVfs()` and
-`sandbox.setLocalVfsUsage({ usedBytes, fileCount })`.
+TypeScript: `await sandbox.refreshLocalVfs('workspace')` and
+`sandbox.setLocalVfsUsage('workspace', { usedBytes, fileCount })`.
 
 #### Rust
 
@@ -621,13 +660,13 @@ use tinysandbox::sandbox::Sandbox;
 use tinysandbox::vfs::{LocalVfs, VfsQuota};
 
 let sandbox = Sandbox::builder()
-    .vfs(LocalVfs::new("/srv/agent-42-workspace")?)
+    .mount("workspace", LocalVfs::new("/srv/agent-42-workspace")?)
     .build();
 
 // Or with quota limits:
 let quota = VfsQuota { max_bytes: 64 << 20, max_files: 4096, max_file_size: 16 << 20 };
 let sandbox = Sandbox::builder()
-    .vfs(LocalVfs::with_quota("/srv/agent-42-workspace", quota)?)
+    .mount("workspace", LocalVfs::with_quota("/srv/agent-42-workspace", quota)?)
     .build();
 ```
 
@@ -637,9 +676,12 @@ let sandbox = Sandbox::builder()
 import { Sandbox } from '@tinysandbox/tinysandbox'
 
 const sandbox = new Sandbox({
-  localVfs: {
-    root: '/srv/agent-42-workspace',
-    quota: { maxBytes: 64 * 1024 * 1024 } // optional; unset limits are unlimited
+  mounts: {
+    workspace: {
+      type: 'local',
+      root: '/srv/agent-42-workspace',
+      quota: { maxBytes: 64 * 1024 * 1024 }
+    }
   }
 })
 ```
@@ -647,8 +689,8 @@ const sandbox = new Sandbox({
 ## Read-only S3 VFS
 
 The optional `s3` Cargo feature provides `S3Vfs`, a read-only view of one S3
-bucket/key prefix. The Node package includes the same backend as the `s3Vfs`
-constructor option. The configured prefix becomes `/`; an empty prefix exposes
+bucket/key prefix. The Node package includes the same backend as the `s3` mount
+type. The configured prefix becomes the backend root. An empty prefix exposes
 the whole bucket, and a prefix with no matching keys is a valid empty virtual
 root. Sandbox path normalization and a fixed prefix boundary prevent access to
 adjacent keys.
@@ -684,9 +726,13 @@ use tinysandbox::vfs::S3Vfs;
 
 async fn run_with_client(client: Client) -> Result<(), Box<dyn std::error::Error>> {
     let vfs = S3Vfs::new(client, "agent-inputs", Some("tenant-42/jobs/current"))?;
-    let sandbox = Sandbox::builder().vfs(vfs).build();
+    let sandbox = Sandbox::builder()
+        .clear_mounts()
+        .mount("input", vfs)
+        .cwd("/input")
+        .build();
 
-    let result = sandbox.exec("grep ERROR /logs/app.log | head").await;
+    let result = sandbox.exec("grep ERROR /input/logs/app.log | head").await;
     println!("{}", result.stdout);
     Ok(())
 }
@@ -707,20 +753,24 @@ fields; `endpointUrl` and `forcePathStyle` support compatible services.
 import { Sandbox } from '@tinysandbox/tinysandbox'
 
 const sandbox = new Sandbox({
-  s3Vfs: {
-    bucket: 'agent-inputs',
-    prefix: 'tenant-42/jobs/current',
-    region: 'us-east-1',
-    endpointUrl: 'http://127.0.0.1:9000', // omit for AWS
-    forcePathStyle: true,                  // commonly needed by compatible APIs
-    credentials: {                        // omit to use the default provider chain
-      accessKeyId: process.env.S3_ACCESS_KEY!,
-      secretAccessKey: process.env.S3_SECRET_KEY!
+  mounts: {
+    input: {
+      type: 's3',
+      bucket: 'agent-inputs',
+      prefix: 'tenant-42/jobs/current',
+      region: 'us-east-1',
+      endpointUrl: 'http://127.0.0.1:9000',
+      forcePathStyle: true,
+      credentials: {
+        accessKeyId: process.env.S3_ACCESS_KEY!,
+        secretAccessKey: process.env.S3_SECRET_KEY!
+      }
     }
-  }
+  },
+  cwd: '/input'
 })
 
-const firstLine = await sandbox.exec('cat /logs/app.log | head -n 1')
+const firstLine = await sandbox.exec('cat /input/logs/app.log | head -n 1')
 ```
 
 The minimal IAM shape is `s3:GetObject` on the exposed keys and
@@ -769,12 +819,12 @@ use std::sync::Arc;
 use tinysandbox::sandbox::Sandbox;
 
 let sandbox = Sandbox::builder()
-    .vfs(MyVfs::connect("s3://agent-42-workspace")?)
+    .mount("workspace", MyVfs::connect("s3://agent-42-workspace")?)
     .build();
 
 // Or share one VFS between sandboxes / keep a handle for yourself:
 let vfs = Arc::new(MyVfs::connect("s3://agent-42-workspace")?);
-let sandbox = Sandbox::builder().vfs_arc(Arc::clone(&vfs)).build();
+let sandbox = Sandbox::builder().mount_arc("workspace", Arc::clone(&vfs)).build();
 ```
 
 #### TypeScript
@@ -783,7 +833,9 @@ let sandbox = Sandbox::builder().vfs_arc(Arc::clone(&vfs)).build();
 import { Sandbox } from '@tinysandbox/tinysandbox'
 
 const sandbox = new Sandbox({
-  vfs: MyVfs.connect('s3://agent-42-workspace')
+  mounts: {
+    workspace: { type: 'custom', vfs: MyVfs.connect('s3://agent-42-workspace') }
+  }
 })
 ```
 
@@ -848,8 +900,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 The Node binding exposes live VFS operations and JS-backed VFS adapters.
 Snapshot capture/restore/branch is currently Rust-only.
 
-`Sandbox::vfs()` returns `Arc<dyn Vfs>`, so snapshot-aware callers should keep
-their own concrete handle and pass a clone into the builder:
+`Sandbox::vfs()` returns the composite mount namespace as `Arc<dyn Vfs>`, so
+snapshot-aware callers should keep their own concrete backend handle and pass a
+clone into the builder:
 
 #### Rust
 
@@ -861,9 +914,9 @@ use tinysandbox::vfs::{InMemoryVfs, VfsQuota, VfsSnapshot};
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let vfs = Arc::new(InMemoryVfs::new(VfsQuota::unlimited()));
-    let sandbox = Sandbox::builder().vfs_arc(vfs.clone()).build();
+    let sandbox = Sandbox::builder().mount_arc("workspace", vfs.clone()).build();
     let before_turn = vfs.snapshot()?;
-    let result = sandbox.exec("echo draft > /answer.txt").await;
+    let result = sandbox.exec("echo draft > /workspace/answer.txt").await;
     if result.exit_code != 0 {
         vfs.restore(&before_turn)?;
     }
@@ -933,7 +986,8 @@ reports VFS usage and total commands run.
   VFS, quotas, and path containment as everything else.
 - **Resources are bounded** per execution: memory (ResourceLimiter), CPU
   (epoch interruption), wall clock, output size, file quotas.
-- `..` traversal is contained at the VFS root; `/bin` is read-only. With
+- `..` traversal is contained at the virtual root. `/bin` and mount points are
+  read-only. With
   the local directory VFS, containment also refuses symlinks and special
   files, so the sandbox cannot reach outside its host directory.
 

--- a/examples/js_scripts.rs
+++ b/examples/js_scripts.rs
@@ -20,7 +20,7 @@ async fn main() {
     // separate exec calls, like one long shell session.
     sandbox
         .exec(concat!(
-            "mkdir -p /app && cd /app && ",
+            "mkdir -p /workspace/app && cd /workspace/app && ",
             r#"echo 'exports.stats = (text) => {
   const words = text.split(/\s+/).filter(Boolean)
   return { words: words.length, unique: new Set(words).size }
@@ -34,7 +34,7 @@ const { stats } = require("./helper.js")
 const text = fs.readFileSync(process.argv[2], "utf8")
 const result = stats(text)
 console.log(JSON.stringify(result))
-fs.writeFileSync("/app/stats.json", JSON.stringify(result))' > main.js"#,
+fs.writeFileSync("/workspace/app/stats.json", JSON.stringify(result))' > main.js"#,
         )
         .await;
 
@@ -50,7 +50,7 @@ fs.writeFileSync("/app/stats.json", JSON.stringify(result))' > main.js"#,
     assert_eq!(result.stdout, "{\"words\":9,\"unique\":8}\n");
 
     // Results land in the VFS like any other file.
-    let result = sandbox.exec("cat /app/stats.json | wc -c").await;
+    let result = sandbox.exec("cat /workspace/app/stats.json | wc -c").await;
     print!("stats.json bytes: {}", result.stdout);
 
     // Peak wasm memory for the run is reported in the metrics.

--- a/examples/js_syscalls.rs
+++ b/examples/js_syscalls.rs
@@ -66,11 +66,11 @@ try {
 "#;
     sandbox
         .fs()
-        .write_file("/main.js", script.as_bytes(), false)
+        .write_file("/workspace/main.js", script.as_bytes(), false)
         .await
         .expect("write example script");
 
-    let result = sandbox.exec("js /main.js").await;
+    let result = sandbox.exec("js /workspace/main.js").await;
     print!("{}", result.stdout);
     assert_eq!(result.exit_code, 0, "stderr: {}", result.stderr);
     assert_eq!(

--- a/src/js/mod.rs
+++ b/src/js/mod.rs
@@ -1253,6 +1253,7 @@ fn libuv_errno(errno: Errno) -> i32 {
     match errno {
         Errno::EBADF => -9,
         Errno::EBUSY => -16,
+        Errno::EXDEV => -18,
         Errno::EACCES => -13,
         Errno::EEXIST => -17,
         Errno::EIO => -5,
@@ -1269,6 +1270,7 @@ fn node_errno_message(errno: Errno) -> &'static str {
     match errno {
         Errno::EBADF => "bad file descriptor",
         Errno::EBUSY => "resource busy or locked",
+        Errno::EXDEV => "cross-device link not permitted",
         Errno::EACCES => "permission denied",
         Errno::EEXIST => "file already exists",
         Errno::EIO => "i/o error",

--- a/src/prompts.rs
+++ b/src/prompts.rs
@@ -24,7 +24,7 @@
 //! depending on the builder's `persist_session` setting.
 
 /// What the environment is and its hard boundaries.
-pub const OVERVIEW: &str = "You are working in a minimal Linux-like sandbox: a bash-compatible shell over a virtual filesystem. Files persist across commands. There is no host filesystem, no other processes, no package manager, and no network access beyond capabilities described here.";
+pub const OVERVIEW: &str = "You are working in a minimal Linux-like sandbox: a bash-compatible shell over a virtual filesystem. Files persist across commands. `ls /` shows the static filesystem mounts and `/bin`. The virtual root and mount points are read-only. There is no host filesystem, no other processes, no package manager, and no network access beyond capabilities described here.";
 
 /// The supported shell subset and what fails to parse.
 pub const SHELL: &str = "The shell supports the common bash subset: pipelines, `&&`/`||`/`;`, redirects (`>`, `>>`, `<`, `2>`, `2>>`, `2>&1`), single/double quotes, backslash escapes, and variables (`$VAR`, `${VAR}`, `$?`, `VAR=x cmd`, `export`, `unset`). Behavior inside this subset matches bash. Globs, command substitution (`$(...)`, backticks), heredocs, `&`, subshells, and brace/tilde expansion are not supported and fail with a clear parse error.";

--- a/src/sandbox/fs.rs
+++ b/src/sandbox/fs.rs
@@ -46,6 +46,18 @@ impl Fs {
     /// Reads directory entries for a path resolved relative to the current directory.
     pub async fn readdir(&self, path: &str) -> VfsResult<Vec<DirEntry>> {
         let path = self.resolve(path);
+        if path == "/" {
+            let mut entries = self.dispatch(move |vfs| vfs.readdir("/")).await?;
+            entries.push(DirEntry {
+                name: "bin".to_owned(),
+                metadata: Metadata {
+                    file_type: FileType::Directory,
+                    len: 0,
+                },
+            });
+            entries.sort_by(|a, b| a.name.cmp(&b.name));
+            return Ok(entries);
+        }
         if path == "/bin" {
             return Ok(self
                 .bin_commands
@@ -360,6 +372,7 @@ pub(crate) fn errno_message(errno: Errno) -> &'static str {
     match errno {
         Errno::EBADF => "Bad file descriptor",
         Errno::EBUSY => "Device or resource busy",
+        Errno::EXDEV => "Invalid cross-device link",
         Errno::EACCES => "Permission denied",
         Errno::EEXIST => "File exists",
         Errno::EIO => "Input/output error",

--- a/src/sandbox/mod.rs
+++ b/src/sandbox/mod.rs
@@ -10,7 +10,7 @@
 //! #     .build()
 //! #     .unwrap()
 //! #     .block_on(async {
-//! let sandbox = Sandbox::builder().vfs(InMemoryVfs::new(VfsQuota::unlimited())).build();
+//! let sandbox = Sandbox::builder().mount("workspace", InMemoryVfs::new(VfsQuota::unlimited())).build();
 //!
 //! let result = sandbox.exec("echo hello").await;
 //! assert_eq!(result.exit_code, 0);
@@ -44,7 +44,8 @@ use crate::shell::{
     self, AndOrList, AndOrOp, Command as AstCommand, Pipeline, Redirect, RedirectOp,
     RedirectTarget, Segment, SimpleCommand, Word,
 };
-use crate::vfs::{Errno, FileType, InMemoryVfs, Metadata, Vfs, VfsError, VfsStats};
+use crate::vfs::mount::validate_mount_name;
+use crate::vfs::{Errno, FileType, InMemoryVfs, Metadata, MountedVfs, Vfs, VfsError, VfsStats};
 
 pub use command::{
     BoxAsyncRead, BoxAsyncWrite, Command, CommandContext, CommandFuture, CommandResult, Limits,
@@ -129,7 +130,7 @@ pub struct Sandbox {
 
 /// Builder for [`Sandbox`].
 pub struct SandboxBuilder {
-    vfs: Arc<dyn Vfs>,
+    mounts: BTreeMap<String, Arc<dyn Vfs>>,
     commands: BTreeMap<String, Arc<dyn Command>>,
     #[cfg(feature = "js")]
     syscalls: Vec<(String, Arc<dyn Syscall>)>,
@@ -181,7 +182,8 @@ impl Sandbox {
     /// operations bounded.
     ///
     /// By default, each exec starts from the sandbox's base session: the
-    /// builder-configured cwd and environment (defaults: `/`, `PWD=/`). Shell mutations
+    /// builder-configured cwd and environment (defaults: `/workspace`,
+    /// `PWD=/workspace`). Shell mutations
     /// such as `cd`, `export`, assignments, and `$?` updates are visible within
     /// that exec and discarded afterward, so concurrent default execs have no
     /// session last-writer-wins hazard. Filesystem mutations always persist.
@@ -788,9 +790,14 @@ impl SandboxBuilder {
         );
 
         let mut env = BTreeMap::new();
-        env.insert("PWD".to_owned(), "/".to_owned());
+        env.insert("PWD".to_owned(), "/workspace".to_owned());
+        let mut mounts = BTreeMap::new();
+        mounts.insert(
+            "workspace".to_owned(),
+            Arc::new(InMemoryVfs::default()) as Arc<dyn Vfs>,
+        );
         Self {
-            vfs: Arc::new(InMemoryVfs::default()),
+            mounts,
             commands,
             #[cfg(feature = "js")]
             syscalls: Vec::new(),
@@ -799,21 +806,39 @@ impl SandboxBuilder {
             #[cfg(feature = "js")]
             js_prelude: None,
             limits: Limits::default(),
-            cwd: "/".to_owned(),
+            cwd: "/workspace".to_owned(),
             env,
             persist_session: false,
         }
     }
 
-    /// Replaces the VFS with a concrete implementation.
-    pub fn vfs(mut self, vfs: impl Vfs + 'static) -> Self {
-        self.vfs = Arc::new(vfs);
+    /// Adds or replaces a top-level mount with a concrete VFS implementation.
+    pub fn mount(mut self, name: impl Into<String>, vfs: impl Vfs + 'static) -> Self {
+        let name = name.into();
+        assert!(
+            validate_mount_name(&name).is_ok(),
+            "SandboxBuilder::mount requires a non-reserved single path component"
+        );
+        self.mounts.insert(name, Arc::new(vfs));
         self
     }
 
-    /// Replaces the VFS with a shared trait object.
-    pub fn vfs_arc(mut self, vfs: Arc<dyn Vfs>) -> Self {
-        self.vfs = vfs;
+    /// Adds or replaces a top-level mount with a shared VFS trait object.
+    pub fn mount_arc(mut self, name: impl Into<String>, vfs: Arc<dyn Vfs>) -> Self {
+        let name = name.into();
+        assert!(
+            validate_mount_name(&name).is_ok(),
+            "SandboxBuilder::mount_arc requires a non-reserved single path component"
+        );
+        self.mounts.insert(name, vfs);
+        self
+    }
+
+    /// Removes all configured mounts.
+    pub fn clear_mounts(mut self) -> Self {
+        self.mounts.clear();
+        self.cwd = "/".to_owned();
+        self.env.insert("PWD".to_owned(), self.cwd.clone());
         self
     }
 
@@ -903,8 +928,11 @@ impl SandboxBuilder {
         #[cfg(feature = "js")]
         let js_prelude = Arc::<str>::from(self.js_prelude.unwrap_or_default());
         let command_names = Arc::new(self.commands.keys().cloned().collect());
+        let vfs = Arc::new(
+            MountedVfs::new(self.mounts).expect("SandboxBuilder validates mount names eagerly"),
+        );
         Sandbox {
-            vfs: self.vfs,
+            vfs,
             commands: Arc::new(self.commands),
             command_names,
             #[cfg(feature = "js")]

--- a/src/vfs/local.rs
+++ b/src/vfs/local.rs
@@ -621,6 +621,7 @@ fn io_error(err: &io::Error) -> VfsError {
         Some(libc::EISDIR) => Errno::EISDIR,
         Some(libc::EEXIST) => Errno::EEXIST,
         Some(libc::ENOTEMPTY) => Errno::ENOTEMPTY,
+        Some(libc::EXDEV) => Errno::EXDEV,
         Some(libc::EACCES | libc::EPERM | libc::ELOOP | libc::EROFS) => Errno::EACCES,
         Some(libc::ENOSPC | libc::EDQUOT | libc::EFBIG) => Errno::ENOSPC,
         Some(libc::EBUSY) => Errno::EBUSY,

--- a/src/vfs/mod.rs
+++ b/src/vfs/mod.rs
@@ -4,6 +4,7 @@ pub mod conformance;
 #[cfg(unix)]
 pub mod local;
 pub mod mem;
+pub mod mount;
 #[cfg(feature = "s3")]
 pub mod s3;
 
@@ -15,6 +16,7 @@ use std::fmt;
 #[cfg(unix)]
 pub use local::LocalVfs;
 pub use mem::{InMemoryVfs, InMemoryVfsSnapshot, VfsQuota, VfsStats};
+pub use mount::MountedVfs;
 #[cfg(feature = "s3")]
 pub use s3::S3Vfs;
 
@@ -29,6 +31,8 @@ pub enum Errno {
     EBADF,
     /// Device or resource busy.
     EBUSY,
+    /// Invalid cross-device link.
+    EXDEV,
     /// Permission denied.
     EACCES,
     /// File exists.
@@ -55,6 +59,7 @@ impl Errno {
         match self {
             Self::EBADF => 9,
             Self::EBUSY => 16,
+            Self::EXDEV => 18,
             Self::EACCES => 13,
             Self::EEXIST => 17,
             Self::EIO => 5,
@@ -72,6 +77,7 @@ impl Errno {
         match self {
             Self::EBADF => "EBADF",
             Self::EBUSY => "EBUSY",
+            Self::EXDEV => "EXDEV",
             Self::EACCES => "EACCES",
             Self::EEXIST => "EEXIST",
             Self::EIO => "EIO",
@@ -356,6 +362,7 @@ mod tests {
         assert_eq!(Errno::EIO.code(), 5);
         assert_eq!(Errno::EACCES.code(), 13);
         assert_eq!(Errno::EBUSY.code(), 16);
+        assert_eq!(Errno::EXDEV.code(), 18);
         assert_eq!(Errno::ENOSPC.code(), 28);
         assert_eq!(Errno::ENOTEMPTY.code(), 39);
         assert_eq!(VfsError::new(Errno::EBADF).code(), 9);

--- a/src/vfs/mount.rs
+++ b/src/vfs/mount.rs
@@ -1,0 +1,398 @@
+//! Static top-level mount routing over existing VFS implementations.
+
+use std::collections::{BTreeMap, HashMap, hash_map::Entry};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, PoisonError};
+
+use super::path::normalize_path;
+use super::{
+    DirEntry, Errno, FileHandle, FileType, Metadata, OpenMode, Vfs, VfsError, VfsResult, VfsStats,
+};
+
+const FIRST_HANDLE: u64 = 1;
+
+struct MountedHandle {
+    vfs: Arc<dyn Vfs>,
+    inner: FileHandle,
+}
+
+/// A read-only virtual root whose immediate children are static VFS mounts.
+///
+/// Mount names are single path components. Each backend remains rooted at `/`:
+/// a request for `/workspace/src/main.rs` is forwarded to the `workspace`
+/// backend as `/src/main.rs`.
+pub struct MountedVfs {
+    mounts: BTreeMap<String, Arc<dyn Vfs>>,
+    handles: Mutex<HashMap<FileHandle, MountedHandle>>,
+    next_handle: AtomicU64,
+    fast: bool,
+}
+
+impl MountedVfs {
+    /// Builds a static mount table.
+    pub fn new(mounts: BTreeMap<String, Arc<dyn Vfs>>) -> VfsResult<Self> {
+        for name in mounts.keys() {
+            validate_mount_name(name)?;
+        }
+        let fast = mounts.values().all(|vfs| vfs.is_fast());
+        Ok(Self {
+            mounts,
+            handles: Mutex::new(HashMap::new()),
+            next_handle: AtomicU64::new(FIRST_HANDLE),
+            fast,
+        })
+    }
+
+    /// Returns the configured mount names in directory-listing order.
+    pub fn mount_names(&self) -> impl Iterator<Item = &str> {
+        self.mounts.keys().map(String::as_str)
+    }
+
+    fn mounted_path(&self, path: &str) -> VfsResult<Option<(String, Arc<dyn Vfs>, String, bool)>> {
+        let components = normalize_path(path)?;
+        let Some(name) = components.first() else {
+            return Ok(None);
+        };
+        let Some(vfs) = self.mounts.get(name) else {
+            return Err(VfsError::new(Errno::ENOENT));
+        };
+        let at_mount = components.len() == 1;
+        let inner = if at_mount {
+            "/".to_owned()
+        } else {
+            format!("/{}", components[1..].join("/"))
+        };
+        Ok(Some((name.clone(), Arc::clone(vfs), inner, at_mount)))
+    }
+
+    fn handle(&self, handle: FileHandle) -> VfsResult<(Arc<dyn Vfs>, FileHandle)> {
+        let handles = self.handles.lock().unwrap_or_else(PoisonError::into_inner);
+        let mounted = handles.get(&handle).ok_or(VfsError::new(Errno::EBADF))?;
+        Ok((Arc::clone(&mounted.vfs), mounted.inner))
+    }
+
+    fn insert_handle(&self, vfs: Arc<dyn Vfs>, inner: FileHandle) -> FileHandle {
+        let mut handles = self.handles.lock().unwrap_or_else(PoisonError::into_inner);
+        loop {
+            let raw = self.next_handle.fetch_add(1, Ordering::Relaxed);
+            if raw == 0 {
+                continue;
+            }
+            let outer = FileHandle::new(raw);
+            if let Entry::Vacant(entry) = handles.entry(outer) {
+                entry.insert(MountedHandle { vfs, inner });
+                return outer;
+            }
+        }
+    }
+}
+
+impl Default for MountedVfs {
+    fn default() -> Self {
+        Self::new(BTreeMap::new()).expect("an empty mount table is valid")
+    }
+}
+
+impl Vfs for MountedVfs {
+    fn stat(&self, path: &str) -> VfsResult<Metadata> {
+        match self.mounted_path(path)? {
+            Some((_, vfs, inner, _)) => vfs.stat(&inner),
+            None => Ok(directory_metadata()),
+        }
+    }
+
+    fn readdir(&self, path: &str) -> VfsResult<Vec<DirEntry>> {
+        match self.mounted_path(path)? {
+            Some((_, vfs, inner, _)) => vfs.readdir(&inner),
+            None => Ok(self
+                .mounts
+                .keys()
+                .map(|name| DirEntry {
+                    name: name.clone(),
+                    metadata: directory_metadata(),
+                })
+                .collect()),
+        }
+    }
+
+    fn mkdir(&self, path: &str) -> VfsResult<()> {
+        match self.mounted_path(path) {
+            Ok(Some((_, _, _, true))) => Err(VfsError::new(Errno::EEXIST)),
+            Ok(Some((_, vfs, inner, false))) => vfs.mkdir(&inner),
+            Ok(None) => Err(VfsError::new(Errno::EACCES)),
+            Err(err) if err.errno() == Errno::ENOENT => Err(VfsError::new(Errno::EACCES)),
+            Err(err) => Err(err),
+        }
+    }
+
+    fn rename(&self, from: &str, to: &str) -> VfsResult<()> {
+        let (from_mount, from_vfs, from_inner, from_root) = self
+            .mounted_path(from)?
+            .ok_or(VfsError::new(Errno::EBUSY))?;
+        if from_root {
+            return Err(VfsError::new(Errno::EBUSY));
+        }
+        let (to_mount, _to_vfs, to_inner, to_root) = self
+            .mounted_path(to)
+            .map_err(|err| {
+                if err.errno() == Errno::ENOENT {
+                    VfsError::new(Errno::EACCES)
+                } else {
+                    err
+                }
+            })?
+            .ok_or(VfsError::new(Errno::EBUSY))?;
+        if to_root {
+            return Err(VfsError::new(Errno::EBUSY));
+        }
+        if from_mount != to_mount {
+            return Err(VfsError::new(Errno::EXDEV));
+        }
+        from_vfs.rename(&from_inner, &to_inner)
+    }
+
+    fn unlink(&self, path: &str) -> VfsResult<()> {
+        match self.mounted_path(path)? {
+            Some((_, _, _, true)) | None => Err(VfsError::new(Errno::EISDIR)),
+            Some((_, vfs, inner, false)) => vfs.unlink(&inner),
+        }
+    }
+
+    fn rmdir(&self, path: &str) -> VfsResult<()> {
+        match self.mounted_path(path)? {
+            Some((_, _, _, true)) | None => Err(VfsError::new(Errno::EBUSY)),
+            Some((_, vfs, inner, false)) => vfs.rmdir(&inner),
+        }
+    }
+
+    fn open(&self, path: &str, mode: OpenMode) -> VfsResult<FileHandle> {
+        let (_, vfs, inner, at_mount) = self
+            .mounted_path(path)?
+            .ok_or(VfsError::new(Errno::EISDIR))?;
+        if at_mount {
+            return Err(VfsError::new(Errno::EISDIR));
+        }
+        let inner_handle = vfs.open(&inner, mode)?;
+        Ok(self.insert_handle(vfs, inner_handle))
+    }
+
+    fn read_at(&self, handle: FileHandle, offset: u64, buf: &mut [u8]) -> VfsResult<usize> {
+        let (vfs, inner) = self.handle(handle)?;
+        vfs.read_at(inner, offset, buf)
+    }
+
+    fn write_at(&self, handle: FileHandle, offset: u64, data: &[u8]) -> VfsResult<usize> {
+        let (vfs, inner) = self.handle(handle)?;
+        vfs.write_at(inner, offset, data)
+    }
+
+    fn truncate(&self, handle: FileHandle, len: u64) -> VfsResult<()> {
+        let (vfs, inner) = self.handle(handle)?;
+        vfs.truncate(inner, len)
+    }
+
+    fn close(&self, handle: FileHandle) -> VfsResult<()> {
+        let mounted = self
+            .handles
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .remove(&handle)
+            .ok_or(VfsError::new(Errno::EBADF))?;
+        mounted.vfs.close(mounted.inner)
+    }
+
+    fn is_fast(&self) -> bool {
+        self.fast
+    }
+
+    fn stats(&self) -> Option<VfsResult<VfsStats>> {
+        let mut total = VfsStats {
+            used_bytes: 0,
+            file_count: 0,
+        };
+        let mut reported = false;
+        for vfs in self.mounts.values() {
+            let Some(stats) = vfs.stats() else {
+                continue;
+            };
+            reported = true;
+            let stats = match stats {
+                Ok(stats) => stats,
+                Err(err) => return Some(Err(err)),
+            };
+            total.used_bytes = match total.used_bytes.checked_add(stats.used_bytes) {
+                Some(value) => value,
+                None => return Some(Err(VfsError::new(Errno::ENOSPC))),
+            };
+            total.file_count = match total.file_count.checked_add(stats.file_count) {
+                Some(value) => value,
+                None => return Some(Err(VfsError::new(Errno::ENOSPC))),
+            };
+        }
+        reported.then_some(Ok(total))
+    }
+}
+
+/// Validates a single-component mount name used immediately beneath `/`.
+pub fn validate_mount_name(name: &str) -> VfsResult<()> {
+    if name.is_empty()
+        || matches!(name, "." | ".." | "bin")
+        || name.contains('/')
+        || name.contains('\0')
+    {
+        return Err(VfsError::new(Errno::EINVAL));
+    }
+    Ok(())
+}
+
+const fn directory_metadata() -> Metadata {
+    Metadata {
+        file_type: FileType::Directory,
+        len: 0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::sync::Arc;
+
+    use super::{MountedVfs, validate_mount_name};
+    use crate::vfs::{Errno, InMemoryVfs, OpenMode, Vfs, VfsQuota};
+
+    fn mounted(entries: &[(&str, Arc<InMemoryVfs>)]) -> MountedVfs {
+        let mounts = entries
+            .iter()
+            .map(|(name, vfs)| ((*name).to_owned(), Arc::clone(vfs) as Arc<dyn Vfs>))
+            .collect::<BTreeMap<_, _>>();
+        MountedVfs::new(mounts).expect("valid mount table")
+    }
+
+    #[test]
+    fn root_and_mount_paths_are_synthesized_and_routed() {
+        let workspace = Arc::new(InMemoryVfs::default());
+        workspace.mkdir("/src").expect("seed backend directory");
+        let input = Arc::new(InMemoryVfs::default());
+        let vfs = mounted(&[
+            ("workspace", Arc::clone(&workspace)),
+            ("input", Arc::clone(&input)),
+        ]);
+
+        assert!(vfs.stat("/").expect("stat virtual root").is_dir());
+        assert!(vfs.stat("/workspace").expect("stat mount root").is_dir());
+        assert!(
+            vfs.stat("/workspace/src")
+                .expect("stat mounted path")
+                .is_dir()
+        );
+        let names = vfs
+            .readdir("/")
+            .expect("list virtual root")
+            .into_iter()
+            .map(|entry| entry.name)
+            .collect::<Vec<_>>();
+        assert_eq!(names, ["input", "workspace"]);
+        assert_eq!(
+            vfs.readdir("/workspace").expect("list mount root")[0].name,
+            "src"
+        );
+        assert_eq!(
+            vfs.stat("/missing").expect_err("unknown mount").errno(),
+            Errno::ENOENT
+        );
+    }
+
+    #[test]
+    fn handles_are_unique_and_route_to_the_opening_mount() {
+        let left = Arc::new(InMemoryVfs::default());
+        let right = Arc::new(InMemoryVfs::default());
+        let vfs = mounted(&[("left", left), ("right", right)]);
+
+        let left_handle = vfs
+            .open("/left/file", OpenMode::read_write().create_new())
+            .expect("open left file");
+        let right_handle = vfs
+            .open("/right/file", OpenMode::read_write().create_new())
+            .expect("open right file");
+        assert_ne!(left_handle, right_handle);
+        vfs.write_at(left_handle, 0, b"left").expect("write left");
+        vfs.write_at(right_handle, 0, b"right")
+            .expect("write right");
+
+        let mut buf = [0; 5];
+        assert_eq!(vfs.read_at(left_handle, 0, &mut buf).expect("read left"), 4);
+        assert_eq!(&buf[..4], b"left");
+        assert_eq!(
+            vfs.read_at(right_handle, 0, &mut buf).expect("read right"),
+            5
+        );
+        assert_eq!(&buf, b"right");
+        vfs.close(left_handle).expect("close left");
+        vfs.close(right_handle).expect("close right");
+    }
+
+    #[test]
+    fn mount_points_are_immutable_and_cross_mount_rename_is_exdev() {
+        let shared = Arc::new(InMemoryVfs::default());
+        let vfs = mounted(&[("one", Arc::clone(&shared)), ("two", Arc::clone(&shared))]);
+        let handle = vfs
+            .open("/one/file", OpenMode::write_only().create_new())
+            .expect("create mounted file");
+        vfs.close(handle).expect("close file");
+
+        assert_eq!(
+            vfs.mkdir("/one").expect_err("mount exists").errno(),
+            Errno::EEXIST
+        );
+        assert_eq!(
+            vfs.rmdir("/one").expect_err("mount is busy").errno(),
+            Errno::EBUSY
+        );
+        assert_eq!(
+            vfs.rename("/one/file", "/two/file")
+                .expect_err("cross-mount rename")
+                .errno(),
+            Errno::EXDEV
+        );
+        assert_eq!(
+            vfs.mkdir("relative")
+                .expect_err("relative path is invalid")
+                .errno(),
+            Errno::EINVAL
+        );
+        assert_eq!(
+            vfs.rename("/one/file", "relative")
+                .expect_err("relative destination is invalid")
+                .errno(),
+            Errno::EINVAL
+        );
+    }
+
+    #[test]
+    fn aggregate_stats_include_reporting_mounts() {
+        let left = Arc::new(InMemoryVfs::new(VfsQuota::unlimited()));
+        let right = Arc::new(InMemoryVfs::new(VfsQuota::unlimited()));
+        left.mkdir("/dir").expect("seed left");
+        right.mkdir("/dir").expect("seed right");
+        let vfs = mounted(&[("left", left), ("right", right)]);
+        let stats = vfs
+            .stats()
+            .expect("stats supported")
+            .expect("stats succeed");
+        assert_eq!(stats.file_count, 2);
+        assert_eq!(stats.used_bytes, 0);
+    }
+
+    #[test]
+    fn mount_names_are_single_non_reserved_components() {
+        for invalid in ["", ".", "..", "bin", "a/b", "nul\0name"] {
+            assert_eq!(
+                validate_mount_name(invalid)
+                    .expect_err("invalid mount name")
+                    .errno(),
+                Errno::EINVAL
+            );
+        }
+        validate_mount_name("workspace").expect("ordinary name");
+    }
+}

--- a/src/vfs/mount.rs
+++ b/src/vfs/mount.rs
@@ -16,6 +16,13 @@ struct MountedHandle {
     inner: FileHandle,
 }
 
+struct MountedPath {
+    mount: String,
+    vfs: Arc<dyn Vfs>,
+    inner: String,
+    at_mount: bool,
+}
+
 /// A read-only virtual root whose immediate children are static VFS mounts.
 ///
 /// Mount names are single path components. Each backend remains rooted at `/`:
@@ -48,7 +55,7 @@ impl MountedVfs {
         self.mounts.keys().map(String::as_str)
     }
 
-    fn mounted_path(&self, path: &str) -> VfsResult<Option<(String, Arc<dyn Vfs>, String, bool)>> {
+    fn mounted_path(&self, path: &str) -> VfsResult<Option<MountedPath>> {
         let components = normalize_path(path)?;
         let Some(name) = components.first() else {
             return Ok(None);
@@ -62,7 +69,12 @@ impl MountedVfs {
         } else {
             format!("/{}", components[1..].join("/"))
         };
-        Ok(Some((name.clone(), Arc::clone(vfs), inner, at_mount)))
+        Ok(Some(MountedPath {
+            mount: name.clone(),
+            vfs: Arc::clone(vfs),
+            inner,
+            at_mount,
+        }))
     }
 
     fn handle(&self, handle: FileHandle) -> VfsResult<(Arc<dyn Vfs>, FileHandle)> {
@@ -96,14 +108,14 @@ impl Default for MountedVfs {
 impl Vfs for MountedVfs {
     fn stat(&self, path: &str) -> VfsResult<Metadata> {
         match self.mounted_path(path)? {
-            Some((_, vfs, inner, _)) => vfs.stat(&inner),
+            Some(path) => path.vfs.stat(&path.inner),
             None => Ok(directory_metadata()),
         }
     }
 
     fn readdir(&self, path: &str) -> VfsResult<Vec<DirEntry>> {
         match self.mounted_path(path)? {
-            Some((_, vfs, inner, _)) => vfs.readdir(&inner),
+            Some(path) => path.vfs.readdir(&path.inner),
             None => Ok(self
                 .mounts
                 .keys()
@@ -117,8 +129,8 @@ impl Vfs for MountedVfs {
 
     fn mkdir(&self, path: &str) -> VfsResult<()> {
         match self.mounted_path(path) {
-            Ok(Some((_, _, _, true))) => Err(VfsError::new(Errno::EEXIST)),
-            Ok(Some((_, vfs, inner, false))) => vfs.mkdir(&inner),
+            Ok(Some(path)) if path.at_mount => Err(VfsError::new(Errno::EEXIST)),
+            Ok(Some(path)) => path.vfs.mkdir(&path.inner),
             Ok(None) => Err(VfsError::new(Errno::EACCES)),
             Err(err) if err.errno() == Errno::ENOENT => Err(VfsError::new(Errno::EACCES)),
             Err(err) => Err(err),
@@ -126,13 +138,13 @@ impl Vfs for MountedVfs {
     }
 
     fn rename(&self, from: &str, to: &str) -> VfsResult<()> {
-        let (from_mount, from_vfs, from_inner, from_root) = self
+        let from = self
             .mounted_path(from)?
             .ok_or(VfsError::new(Errno::EBUSY))?;
-        if from_root {
+        if from.at_mount {
             return Err(VfsError::new(Errno::EBUSY));
         }
-        let (to_mount, _to_vfs, to_inner, to_root) = self
+        let to = self
             .mounted_path(to)
             .map_err(|err| {
                 if err.errno() == Errno::ENOENT {
@@ -142,38 +154,40 @@ impl Vfs for MountedVfs {
                 }
             })?
             .ok_or(VfsError::new(Errno::EBUSY))?;
-        if to_root {
+        if to.at_mount {
             return Err(VfsError::new(Errno::EBUSY));
         }
-        if from_mount != to_mount {
+        if from.mount != to.mount {
             return Err(VfsError::new(Errno::EXDEV));
         }
-        from_vfs.rename(&from_inner, &to_inner)
+        from.vfs.rename(&from.inner, &to.inner)
     }
 
     fn unlink(&self, path: &str) -> VfsResult<()> {
         match self.mounted_path(path)? {
-            Some((_, _, _, true)) | None => Err(VfsError::new(Errno::EISDIR)),
-            Some((_, vfs, inner, false)) => vfs.unlink(&inner),
+            Some(path) if path.at_mount => Err(VfsError::new(Errno::EISDIR)),
+            Some(path) => path.vfs.unlink(&path.inner),
+            None => Err(VfsError::new(Errno::EISDIR)),
         }
     }
 
     fn rmdir(&self, path: &str) -> VfsResult<()> {
         match self.mounted_path(path)? {
-            Some((_, _, _, true)) | None => Err(VfsError::new(Errno::EBUSY)),
-            Some((_, vfs, inner, false)) => vfs.rmdir(&inner),
+            Some(path) if path.at_mount => Err(VfsError::new(Errno::EBUSY)),
+            Some(path) => path.vfs.rmdir(&path.inner),
+            None => Err(VfsError::new(Errno::EBUSY)),
         }
     }
 
     fn open(&self, path: &str, mode: OpenMode) -> VfsResult<FileHandle> {
-        let (_, vfs, inner, at_mount) = self
+        let path = self
             .mounted_path(path)?
             .ok_or(VfsError::new(Errno::EISDIR))?;
-        if at_mount {
+        if path.at_mount {
             return Err(VfsError::new(Errno::EISDIR));
         }
-        let inner_handle = vfs.open(&inner, mode)?;
-        Ok(self.insert_handle(vfs, inner_handle))
+        let inner_handle = path.vfs.open(&path.inner, mode)?;
+        Ok(self.insert_handle(path.vfs, inner_handle))
     }
 
     fn read_at(&self, handle: FileHandle, offset: u64, buf: &mut [u8]) -> VfsResult<usize> {

--- a/tests/fixtures/sandbox_builtins_golden.txt
+++ b/tests/fixtures/sandbox_builtins_golden.txt
@@ -19,7 +19,7 @@ END
 
 CASE ls all long shape
 COMMAND
-mkdir -p /d; touch /d/.hidden /d/file; ls -a -l /d
+mkdir -p /workspace/d; touch /workspace/d/.hidden /workspace/d/file; ls -a -l /workspace/d
 END_COMMAND
 EXIT 0
 STDOUT
@@ -34,13 +34,13 @@ END
 
 CASE cp mv rm mkdir touch
 COMMAND
-mkdir -p /a; echo data > /a/src; cp /a/src /a/copy; mkdir /b; mv /a/copy /b/moved; rm /a/src; ls /a /b
+mkdir -p /workspace/a; echo data > /workspace/a/src; cp /workspace/a/src /workspace/a/copy; mkdir /workspace/b; mv /workspace/a/copy /workspace/b/moved; rm /workspace/a/src; ls /workspace/a /workspace/b
 END_COMMAND
 EXIT 0
 STDOUT
-/a:
+/workspace/a:
 
-/b:
+/workspace/b:
 moved
 END_STDOUT
 STDERR
@@ -62,11 +62,11 @@ END
 
 CASE pwd after cd
 COMMAND
-mkdir -p /work; cd /work; pwd
+mkdir -p /workspace/work; cd /workspace/work; pwd
 END_COMMAND
 EXIT 0
 STDOUT
-/work
+/workspace/work
 END_STDOUT
 STDERR
 END_STDERR
@@ -74,7 +74,7 @@ END
 
 CASE grep flags and no match
 COMMAND
-echo -e 'Alpha\nbeta\nALPHA' > /g; grep -i -n alpha /g; grep -c -v beta /g; grep zzz /g
+echo -e 'Alpha\nbeta\nALPHA' > /workspace/g; grep -i -n alpha /workspace/g; grep -c -v beta /workspace/g; grep zzz /workspace/g
 END_COMMAND
 EXIT 1
 STDOUT
@@ -88,25 +88,25 @@ END
 
 CASE grep read error exits two
 COMMAND
-echo ok > /g; grep ok /g /missing
+echo ok > /workspace/g; grep ok /workspace/g /workspace/missing
 END_COMMAND
 EXIT 2
 STDOUT
-/g:ok
+/workspace/g:ok
 END_STDOUT
 STDERR
-grep: /missing: No such file or directory
+grep: /workspace/missing: No such file or directory
 END_STDERR
 END
 
 CASE grep recursive prefixes paths
 COMMAND
-mkdir -p /r; echo one > /r/a; echo two > /r/b; grep -r o /r
+mkdir -p /workspace/r; echo one > /workspace/r/a; echo two > /workspace/r/b; grep -r o /workspace/r
 END_COMMAND
 EXIT 0
 STDOUT
-/r/a:one
-/r/b:two
+/workspace/r/a:one
+/workspace/r/b:two
 END_STDOUT
 STDERR
 END_STDERR
@@ -114,14 +114,14 @@ END
 
 CASE head tail headers and plus count
 COMMAND
-echo -e 'a\nb\nc' > /h1; echo -e 'd\ne\nf' > /h2; head -n 1 /h1 /h2; tail -n +2 /h1
+echo -e 'a\nb\nc' > /workspace/h1; echo -e 'd\ne\nf' > /workspace/h2; head -n 1 /workspace/h1 /workspace/h2; tail -n +2 /workspace/h1
 END_COMMAND
 EXIT 0
 STDOUT
-==> /h1 <==
+==> /workspace/h1 <==
 a
 
-==> /h2 <==
+==> /workspace/h2 <==
 d
 b
 c
@@ -174,7 +174,7 @@ END
 
 CASE uniq count repeated unique
 COMMAND
-echo -e 'a\na\nb\nc\nc' > /u; uniq -c /u; uniq -d /u; uniq -u /u
+echo -e 'a\na\nb\nc\nc' > /workspace/u; uniq -c /workspace/u; uniq -d /workspace/u; uniq -u /workspace/u
 END_COMMAND
 EXIT 0
 STDOUT
@@ -191,14 +191,14 @@ END
 
 CASE wc width rules
 COMMAND
-echo -e -n 'one two\n' | wc; echo -e 'a b\nc' > /w; wc -l /w; wc -l -w -c /w /w
+echo -e -n 'one two\n' | wc; echo -e 'a b\nc' > /workspace/w; wc -l /workspace/w; wc -l -w -c /workspace/w /workspace/w
 END_COMMAND
 EXIT 0
 STDOUT
       1       2       8
-2 /w
- 2  3  6 /w
- 2  3  6 /w
+2 /workspace/w
+ 2  3  6 /workspace/w
+ 2  3  6 /workspace/w
  4  6 12 total
 END_STDOUT
 STDERR
@@ -238,7 +238,7 @@ END
 
 CASE cat numbering squeeze and marks
 COMMAND
-echo -e 'a\tx\n\n\n\nb' > /f; cat -n /f; cat -b /f; cat -sn /f; cat -ET /f
+echo -e 'a\tx\n\n\n\nb' > /workspace/f; cat -n /workspace/f; cat -b /workspace/f; cat -sn /workspace/f; cat -ET /workspace/f
 END_COMMAND
 EXIT 0
 STDOUT
@@ -267,7 +267,7 @@ END
 
 CASE cat numbering continues across files
 COMMAND
-echo -e 'p\nq' > /g; cat -n /g /g
+echo -e 'p\nq' > /workspace/g; cat -n /workspace/g /workspace/g
 END_COMMAND
 EXIT 0
 STDOUT
@@ -282,7 +282,7 @@ END
 
 CASE cat unsupported flag
 COMMAND
-cat -z /g
+cat -z /workspace/g
 END_COMMAND
 EXIT 1
 STDOUT
@@ -330,7 +330,7 @@ END
 
 CASE jq raw output files and dash
 COMMAND
-echo '{"x":1}' > /a; echo '{"x":3}' > /c; echo '{"x":2}' | jq -r '.x' /a - /c
+echo '{"x":1}' > /workspace/a; echo '{"x":3}' > /workspace/c; echo '{"x":2}' | jq -r '.x' /workspace/a - /workspace/c
 END_COMMAND
 EXIT 0
 STDOUT

--- a/tests/js_runtime.rs
+++ b/tests/js_runtime.rs
@@ -897,22 +897,22 @@ async fn js_fs_sync_surface_round_trips_text_binary_and_offsets() {
     let sandbox = Sandbox::builder().build();
     let script = r#"
 const fs = require('fs')
-fs.mkdirSync('/work', { recursive: true })
-fs.writeFileSync('/work/text.txt', 'hello')
-fs.appendFileSync('/work/text.txt', ' world')
-const fd = fs.openSync('/work/bin', 'w+')
+fs.mkdirSync('/workspace/work', { recursive: true })
+fs.writeFileSync('/workspace/work/text.txt', 'hello')
+fs.appendFileSync('/workspace/work/text.txt', ' world')
+const fd = fs.openSync('/workspace/work/bin', 'w+')
 fs.writeSync(fd, Buffer.from([1, 2, 3, 4]), 0, 4, 0)
 fs.writeSync(fd, Buffer.from([9]), 0, 1, 2)
 fs.ftruncateSync(fd, 3)
 fs.closeSync(fd)
 const input = Buffer.alloc(4)
-const readFd = fs.openSync('/work/bin', 'r')
+const readFd = fs.openSync('/workspace/work/bin', 'r')
 const n = fs.readSync(readFd, input, 1, 3, 0)
 fs.closeSync(readFd)
-console.log(fs.readFileSync('/work/text.txt', 'utf8'))
+console.log(fs.readFileSync('/workspace/work/text.txt', 'utf8'))
 console.log(n, Array.from(input).join(','))
-console.log(fs.readdirSync('/work').join(','))
-const stat = fs.statSync('/work/bin')
+console.log(fs.readdirSync('/workspace/work').join(','))
+const stat = fs.statSync('/workspace/work/bin')
 console.log(stat.isFile(), stat.isDirectory(), stat.size)
 "#;
 
@@ -936,18 +936,18 @@ const fs = require('fs')
 function dump(path, options) {
   console.log(JSON.stringify(Array.from(fs.readLinesSync(path, options))))
 }
-fs.writeFileSync('/normal', 'alpha\nbeta\n')
-fs.writeFileSync('/mixed', 'a\r\nb\n\nc')
-fs.writeFileSync('/unterminated', 'last')
-fs.writeFileSync('/blank', '\n\nmiddle\n\n')
-const iterator = fs.readLinesSync('/normal')
+fs.writeFileSync('/workspace/normal', 'alpha\nbeta\n')
+fs.writeFileSync('/workspace/mixed', 'a\r\nb\n\nc')
+fs.writeFileSync('/workspace/unterminated', 'last')
+fs.writeFileSync('/workspace/blank', '\n\nmiddle\n\n')
+const iterator = fs.readLinesSync('/workspace/normal')
 console.log(typeof iterator[Symbol.iterator], iterator === iterator[Symbol.iterator]())
 const normal = []
 for (const line of iterator) normal.push(line)
 console.log(JSON.stringify(normal))
-dump('/mixed', 'utf8')
-dump('/unterminated', { encoding: 'utf-8' })
-dump('/blank')
+dump('/workspace/mixed', 'utf8')
+dump('/workspace/unterminated', { encoding: 'utf-8' })
+dump('/workspace/blank')
 "#;
 
     let result = sandbox
@@ -967,21 +967,24 @@ async fn js_fs_read_lines_sync_closes_fd_after_iteration_stops() {
     // fd closes. The follow-up write would fail with ENOSPC if the iterator
     // leaked the descriptor on break, throw, or exhaustion.
     let sandbox = Sandbox::builder()
-        .vfs(InMemoryVfs::new(VfsQuota {
-            max_bytes: 4,
-            max_files: 8,
-            max_file_size: 4,
-        }))
+        .mount(
+            "workspace",
+            InMemoryVfs::new(VfsQuota {
+                max_bytes: 4,
+                max_files: 8,
+                max_file_size: 4,
+            }),
+        )
         .build();
     let script = r#"
 const fs = require('fs')
 function releaseAfter(label, consume) {
-  fs.writeFileSync('/input', 'a\nb\n')
-  consume(fs.readLinesSync('/input'))
-  fs.unlinkSync('/input')
-  fs.writeFileSync(`/${label}`, 'x')
-  console.log(label, fs.readFileSync(`/${label}`, 'utf8'))
-  fs.unlinkSync(`/${label}`)
+  fs.writeFileSync('/workspace/input', 'a\nb\n')
+  consume(fs.readLinesSync('/workspace/input'))
+  fs.unlinkSync('/workspace/input')
+  fs.writeFileSync(`/workspace/${label}`, 'x')
+  console.log(label, fs.readFileSync(`/workspace/${label}`, 'utf8'))
+  fs.unlinkSync(`/workspace/${label}`)
 }
 releaseAfter('break', iter => {
   for (const line of iter) {
@@ -1021,11 +1024,11 @@ async fn js_fs_write_buffer_two_arg_form_writes_all_bytes() {
     let sandbox = Sandbox::builder().build();
     let script = r#"
 const fs = require('fs')
-fs.writeFileSync('/out', '')
-const fd = fs.openSync('/out', 'r+')
+fs.writeFileSync('/workspace/out', '')
+const fd = fs.openSync('/workspace/out', 'r+')
 const n = fs.writeSync(fd, Buffer.from('hello'))
 fs.closeSync(fd)
-console.log(n, fs.readFileSync('/out').toString())
+console.log(n, fs.readFileSync('/workspace/out').toString())
 "#;
 
     let result = sandbox
@@ -1043,10 +1046,10 @@ async fn js_fs_buffer_to_string_and_is_buffer_match_node() {
     let sandbox = Sandbox::builder().build();
     let script = r#"
 const fs = require('fs')
-fs.writeFileSync('/text', 'hello')
-console.log(fs.readFileSync('/text').toString())
+fs.writeFileSync('/workspace/text', 'hello')
+console.log(fs.readFileSync('/workspace/text').toString())
 console.log(Buffer.from('hi').toString('utf8'))
-console.log(Buffer.isBuffer(fs.readFileSync('/text')), Buffer.isBuffer(new Uint8Array()))
+console.log(Buffer.isBuffer(fs.readFileSync('/workspace/text')), Buffer.isBuffer(new Uint8Array()))
 "#;
 
     let result = sandbox
@@ -1070,16 +1073,18 @@ async fn js_fs_large_binary_payloads_round_trip_under_memory_cap() {
     write_vfs_file(vfs.as_ref(), "/big.bin", &input);
 
     let sandbox_vfs: Arc<dyn Vfs> = vfs.clone();
-    let sandbox = Sandbox::builder().vfs_arc(sandbox_vfs).build();
+    let sandbox = Sandbox::builder()
+        .mount_arc("workspace", sandbox_vfs)
+        .build();
     let spot_index = 1_234_567;
     let script = format!(
         r#"
 const fs = require('fs')
-const data = fs.readFileSync('/big.bin')
+const data = fs.readFileSync('/workspace/big.bin')
 console.log(data.length, data[0], data[{spot_index}], data[data.length - 1])
-fs.writeFileSync('/copy.bin', data)
-fs.writeFileSync('/small', 'abc')
-const fd = fs.openSync('/small', 'r')
+fs.writeFileSync('/workspace/copy.bin', data)
+fs.writeFileSync('/workspace/small', 'abc')
+const fd = fs.openSync('/workspace/small', 'r')
 const small = Buffer.alloc(16)
 const n = fs.readSync(fd, small, 0, 20 * 1024 * 1024, 0)
 fs.closeSync(fd)
@@ -1111,11 +1116,11 @@ async fn js_fs_write_string_position_overload_matches_node() {
     let sandbox = Sandbox::builder().build();
     let script = r#"
 const fs = require('fs')
-fs.writeFileSync('/out', 'hello world')
-const fd = fs.openSync('/out', 'r+')
+fs.writeFileSync('/workspace/out', 'hello world')
+const fd = fs.openSync('/workspace/out', 'r+')
 const n = fs.writeSync(fd, 'XY', 0)
 fs.closeSync(fd)
-console.log(n, fs.readFileSync('/out', 'utf8'))
+console.log(n, fs.readFileSync('/workspace/out', 'utf8'))
 "#;
 
     let result = sandbox
@@ -1159,10 +1164,10 @@ async fn js_fs_readdir_with_file_types_returns_dirents() {
     let sandbox = Sandbox::builder().build();
     let script = r#"
 const fs = require('fs')
-fs.mkdirSync('/dir')
-fs.writeFileSync('/dir/file', 'x')
-fs.mkdirSync('/dir/sub')
-const entries = fs.readdirSync('/dir', { withFileTypes: true })
+fs.mkdirSync('/workspace/dir')
+fs.writeFileSync('/workspace/dir/file', 'x')
+fs.mkdirSync('/workspace/dir/sub')
+const entries = fs.readdirSync('/workspace/dir', { withFileTypes: true })
   .sort((a, b) => a.name.localeCompare(b.name))
 for (const entry of entries) console.log(entry.name, entry.isFile(), entry.isDirectory())
 "#;
@@ -1181,9 +1186,9 @@ async fn js_fs_errors_use_libuv_errno_values() {
     let sandbox = Sandbox::builder().build();
     let script = r#"
 const fs = require('fs')
-fs.mkdirSync('/dir')
-fs.writeFileSync('/dir/file', 'x')
-try { fs.rmdirSync('/dir') } catch (err) { console.log(err.code, err.errno) }
+fs.mkdirSync('/workspace/dir')
+fs.writeFileSync('/workspace/dir/file', 'x')
+try { fs.rmdirSync('/workspace/dir') } catch (err) { console.log(err.code, err.errno) }
 "#;
 
     let result = sandbox
@@ -1227,17 +1232,20 @@ async fn js_fs_errors_are_node_shaped_and_quota_errors_surface() {
     // JS catches errno-shaped errors from the VFS and sees the Node-style code
     // and message fields rather than a Rust/internal failure.
     let sandbox = Sandbox::builder()
-        .vfs(InMemoryVfs::new(VfsQuota {
-            max_bytes: 4,
-            max_files: 8,
-            max_file_size: 4,
-        }))
+        .mount(
+            "workspace",
+            InMemoryVfs::new(VfsQuota {
+                max_bytes: 4,
+                max_files: 8,
+                max_file_size: 4,
+            }),
+        )
         .build();
     let script = r#"
 const fs = require('fs')
-try { fs.readFileSync('/missing') } catch (err) { console.log(err.code, err.message) }
-try { fs.writeFileSync('/too-big', 'abcdef') } catch (err) { console.log(err.code, err.message) }
-console.log(fs.existsSync('/missing'))
+try { fs.readFileSync('/workspace/missing') } catch (err) { console.log(err.code, err.message) }
+try { fs.writeFileSync('/workspace/too-big', 'abcdef') } catch (err) { console.log(err.code, err.message) }
+console.log(fs.existsSync('/workspace/missing'))
 "#;
 
     let result = sandbox
@@ -1247,12 +1255,12 @@ console.log(fs.existsSync('/missing'))
     assert!(
         result
             .stdout
-            .contains("ENOENT ENOENT: no such file or directory, open '/missing'")
+            .contains("ENOENT ENOENT: no such file or directory, open '/workspace/missing'")
     );
     assert!(
         result
             .stdout
-            .contains("ENOSPC ENOSPC: no space left on device, open '/too-big'")
+            .contains("ENOSPC ENOSPC: no space left on device, open '/workspace/too-big'")
     );
     assert!(result.stdout.ends_with("false\n"));
 }
@@ -1273,7 +1281,7 @@ const h = require('./helper.js')
 console.log(h.fn())
 console.log(require('./helper') === h)
 console.log(require('./sub/child').value)
-console.log(require('/app/dir'))
+console.log(require('/workspace/app/dir'))
 console.log(require('./data').name, require('./data.json').flag)
 console.log(__filename)
 console.log(__dirname)
@@ -1299,16 +1307,16 @@ console.log(require('./sub/main-check'))
     );
     let sandbox_vfs: Arc<dyn Vfs> = vfs;
     let sandbox = Sandbox::builder()
-        .vfs_arc(sandbox_vfs)
-        .cwd("/elsewhere")
+        .mount_arc("workspace", sandbox_vfs)
+        .cwd("/workspace/elsewhere")
         .build();
 
-    let result = sandbox.exec("js /app/main.js").await;
+    let result = sandbox.exec("js /workspace/app/main.js").await;
 
     assert_eq!(result.exit_code, 0, "stderr: {}", result.stderr);
     assert_eq!(
         result.stdout,
-        "help:/app:/app/helper.js\ntrue\nhelp:/app:/app/helper.js\nindexed\ntinysandbox true\n/app/main.js\n/app\ntrue\nfalse\n"
+        "help:/workspace/app:/workspace/app/helper.js\ntrue\nhelp:/workspace/app:/workspace/app/helper.js\nindexed\ntinysandbox true\n/workspace/app/main.js\n/workspace/app\ntrue\nfalse\n"
     );
 }
 
@@ -1328,7 +1336,7 @@ async fn js_commonjs_trailing_slash_uses_directory_resolution_only() {
 console.log(require('./dir/'))
 try { require('./x/') } catch (err) {
   console.log(err.code)
-  console.log(err.message === "Cannot find module './x/'\nRequire stack:\n- /app/main.js")
+  console.log(err.message === "Cannot find module './x/'\nRequire stack:\n- /workspace/app/main.js")
 }
 "#,
             ),
@@ -1338,9 +1346,11 @@ try { require('./x/') } catch (err) {
         ],
     );
     let sandbox_vfs: Arc<dyn Vfs> = vfs;
-    let sandbox = Sandbox::builder().vfs_arc(sandbox_vfs).build();
+    let sandbox = Sandbox::builder()
+        .mount_arc("workspace", sandbox_vfs)
+        .build();
 
-    let result = sandbox.exec("js /app/main.js").await;
+    let result = sandbox.exec("js /workspace/app/main.js").await;
 
     assert_eq!(result.exit_code, 0, "stderr: {}", result.stderr);
     assert_eq!(result.stdout, "index\nMODULE_NOT_FOUND\ntrue\n");
@@ -1369,9 +1379,11 @@ console.log(require('./sub/child'))
         ],
     );
     let sandbox_vfs: Arc<dyn Vfs> = vfs;
-    let sandbox = Sandbox::builder().vfs_arc(sandbox_vfs).build();
+    let sandbox = Sandbox::builder()
+        .mount_arc("workspace", sandbox_vfs)
+        .build();
 
-    let result = sandbox.exec("js /app/main.js").await;
+    let result = sandbox.exec("js /workspace/app/main.js").await;
 
     assert_eq!(result.exit_code, 0, "stderr: {}", result.stderr);
     assert_eq!(result.stdout, "app-index\napp-index\n");
@@ -1422,9 +1434,11 @@ exports.done = true
         ],
     );
     let sandbox_vfs: Arc<dyn Vfs> = vfs;
-    let sandbox = Sandbox::builder().vfs_arc(sandbox_vfs).build();
+    let sandbox = Sandbox::builder()
+        .mount_arc("workspace", sandbox_vfs)
+        .build();
 
-    let result = sandbox.exec("js /app/main.js").await;
+    let result = sandbox.exec("js /workspace/app/main.js").await;
 
     assert_eq!(result.exit_code, 0, "stderr: {}", result.stderr);
     assert_eq!(
@@ -1446,7 +1460,7 @@ async fn js_commonjs_reports_module_not_found_and_bare_specifiers_loudly() {
             r#"
 try { require('./missing') } catch (err) {
   console.log(err.code)
-  console.log(err.message === "Cannot find module './missing'\nRequire stack:\n- /app/main.js")
+  console.log(err.message === "Cannot find module './missing'\nRequire stack:\n- /workspace/app/main.js")
   console.log(err.requireStack.join('|'))
 }
 try { require('left-pad') } catch (err) {
@@ -1457,14 +1471,16 @@ try { require('left-pad') } catch (err) {
         )],
     );
     let sandbox_vfs: Arc<dyn Vfs> = vfs;
-    let sandbox = Sandbox::builder().vfs_arc(sandbox_vfs).build();
+    let sandbox = Sandbox::builder()
+        .mount_arc("workspace", sandbox_vfs)
+        .build();
 
-    let result = sandbox.exec("js /app/main.js").await;
+    let result = sandbox.exec("js /workspace/app/main.js").await;
 
     assert_eq!(result.exit_code, 0, "stderr: {}", result.stderr);
     assert_eq!(
         result.stdout,
-        "MODULE_NOT_FOUND\ntrue\n/app/main.js\nMODULE_NOT_FOUND\ntrue\n"
+        "MODULE_NOT_FOUND\ntrue\n/workspace/app/main.js\nMODULE_NOT_FOUND\ntrue\n"
     );
 }
 
@@ -1484,7 +1500,7 @@ console.log(JSON.stringify(require('./alias')))
 console.log(require('./valid.json').nested.value)
 try { require('./bad.json') } catch (err) {
   console.log(err.name)
-  console.log(err.message.includes('/app/bad.json'))
+  console.log(err.message.includes('/workspace/app/bad.json'))
   console.log(err.code === undefined)
 }
 "#,
@@ -1504,9 +1520,11 @@ exports.d = 5
         ],
     );
     let sandbox_vfs: Arc<dyn Vfs> = vfs;
-    let sandbox = Sandbox::builder().vfs_arc(sandbox_vfs).build();
+    let sandbox = Sandbox::builder()
+        .mount_arc("workspace", sandbox_vfs)
+        .build();
 
-    let result = sandbox.exec("js /app/main.js").await;
+    let result = sandbox.exec("js /workspace/app/main.js").await;
 
     assert_eq!(result.exit_code, 0, "stderr: {}", result.stderr);
     assert_eq!(result.stdout, "{\"c\":4}\n7\nSyntaxError\ntrue\ntrue\n");
@@ -1534,14 +1552,16 @@ boom()
         ],
     );
     let sandbox_vfs: Arc<dyn Vfs> = vfs;
-    let sandbox = Sandbox::builder().vfs_arc(sandbox_vfs).build();
+    let sandbox = Sandbox::builder()
+        .mount_arc("workspace", sandbox_vfs)
+        .build();
 
-    let result = sandbox.exec("js /app/main.js").await;
+    let result = sandbox.exec("js /workspace/app/main.js").await;
 
     assert_eq!(result.exit_code, 1);
     assert!(result.stderr.starts_with("Error: helper boom\n"));
     assert!(
-        result.stderr.contains("/app/helper.js"),
+        result.stderr.contains("/workspace/app/helper.js"),
         "{}",
         result.stderr
     );
@@ -1589,13 +1609,15 @@ async fn js_commonjs_deep_require_chains_are_bounded_cleanly() {
         b"try { require('./m0'); console.log('unexpected') } catch (err) { console.log(err.code); console.log(err.message.includes('256')) }\n",
     );
     let sandbox_vfs: Arc<dyn Vfs> = vfs;
-    let sandbox = Sandbox::builder().vfs_arc(sandbox_vfs).build();
+    let sandbox = Sandbox::builder()
+        .mount_arc("workspace", sandbox_vfs)
+        .build();
 
-    let successful = sandbox.exec("js /chain/main.js").await;
+    let successful = sandbox.exec("js /workspace/chain/main.js").await;
     assert_eq!(successful.exit_code, 0, "stderr: {}", successful.stderr);
     assert_eq!(successful.stdout, "200\n");
 
-    let capped = sandbox.exec("js /cap/main.js").await;
+    let capped = sandbox.exec("js /workspace/cap/main.js").await;
     assert_eq!(capped.exit_code, 0, "stderr: {}", capped.stderr);
     assert_eq!(capped.stdout, "ERR_REQUIRE_DEPTH\ntrue\n");
     assert!(!capped.stderr.contains("wasm trap"));
@@ -1608,12 +1630,14 @@ async fn js_pipeline_and_redirects_use_command_stdio() {
     let sandbox = Sandbox::builder().build();
     assert_eq!(
         sandbox
-            .exec("js -e 'console.log(\"alpha\"); console.log(\"beta\")' | grep beta > /out")
+            .exec(
+                "js -e 'console.log(\"alpha\"); console.log(\"beta\")' | grep beta > /workspace/out"
+            )
             .await
             .exit_code,
         0
     );
-    assert_eq!(sandbox.exec("cat /out").await.stdout, "beta\n");
+    assert_eq!(sandbox.exec("cat /workspace/out").await.stdout, "beta\n");
 }
 
 #[tokio::test]

--- a/tests/sandbox_e2e.rs
+++ b/tests/sandbox_e2e.rs
@@ -177,26 +177,29 @@ async fn jq_builtin_matches_supported_cli_surface() {
 
     assert_eq!(
         sandbox
-            .exec(r#"echo '{"x":1}' > /a; echo '{"x":2}' > /b; jq -r '.x' /a /b"#)
+            .exec(r#"echo '{"x":1}' > /workspace/a; echo '{"x":2}' > /workspace/b; jq -r '.x' /workspace/a /workspace/b"#)
             .await
             .stdout,
         "1\n2\n"
     );
 
     let fs = sandbox.fs();
-    fs.write_file("/jq-one", b"1", false)
+    fs.write_file("/workspace/jq-one", b"1", false)
         .await
         .expect("write jq-one");
-    fs.write_file("/jq-three", b"3", false)
+    fs.write_file("/workspace/jq-three", b"3", false)
         .await
         .expect("write jq-three");
     assert_eq!(
-        sandbox.exec("jq -r '.' /jq-one /jq-three").await.stdout,
+        sandbox
+            .exec("jq -r '.' /workspace/jq-one /workspace/jq-three")
+            .await
+            .stdout,
         "1\n3\n"
     );
     assert_eq!(
         sandbox
-            .exec("echo -n 2 | jq -r '.' /jq-one - /jq-three")
+            .exec("echo -n 2 | jq -r '.' /workspace/jq-one - /workspace/jq-three")
             .await
             .stdout,
         "1\n2\n3\n"
@@ -263,10 +266,10 @@ async fn jq_builtin_reports_status_errors_and_limits() {
     let deep_json = format!("{}0{}", "[".repeat(1100), "]".repeat(1100));
     sandbox
         .fs()
-        .write_file("/deep.json", deep_json.as_bytes(), false)
+        .write_file("/workspace/deep.json", deep_json.as_bytes(), false)
         .await
         .expect("write deep jq input");
-    let deep_input = sandbox.exec("jq -c '.' /deep.json").await;
+    let deep_input = sandbox.exec("jq -c '.' /workspace/deep.json").await;
     assert_eq!(deep_input.exit_code, 2);
     assert!(deep_input.stderr.contains("JSON nesting exceeds"));
 
@@ -328,6 +331,32 @@ async fn bin_is_synthesized_and_read_only() {
     let denied = sandbox.exec("echo x > /bin/cat").await;
     assert_ne!(denied.exit_code, 0);
     assert!(denied.stderr.contains("Permission denied"));
+
+    assert_eq!(sandbox.exec("ls /").await.stdout, "bin\nworkspace\n");
+}
+
+#[tokio::test]
+async fn multiple_mounts_are_listed_routed_and_cross_copied() {
+    let sandbox = Sandbox::builder()
+        .clear_mounts()
+        .mount("input", InMemoryVfs::default())
+        .mount("output", InMemoryVfs::default())
+        .cwd("/input")
+        .build();
+
+    assert_eq!(sandbox.exec("ls /").await.stdout, "bin\ninput\noutput\n");
+    assert_eq!(
+        sandbox
+            .exec("echo mounted > /input/source; cp /input/source /output/copied")
+            .await
+            .exit_code,
+        0
+    );
+    assert_eq!(sandbox.exec("cat /output/copied").await.stdout, "mounted\n");
+
+    let rename = sandbox.exec("mv /input/source /output/moved").await;
+    assert_eq!(rename.exit_code, 1);
+    assert!(rename.stderr.contains("Invalid cross-device link"));
 }
 
 #[tokio::test]
@@ -336,14 +365,29 @@ async fn file_basenames_are_used_for_ls_cp_and_mv_directory_targets() {
     // including paths with trailing slashes after normalization.
     let sandbox = Sandbox::builder().build();
 
-    assert_eq!(sandbox.exec("mkdir /dir; touch /leaf").await.exit_code, 0);
-    assert_eq!(sandbox.exec("ls /leaf///").await.stdout, "leaf\n");
-    assert_eq!(sandbox.exec("cp /leaf/// /dir").await.exit_code, 0);
     assert_eq!(
-        sandbox.exec("mv /dir/leaf/// /dir/moved").await.exit_code,
+        sandbox
+            .exec("mkdir /workspace/dir; touch /workspace/leaf")
+            .await
+            .exit_code,
         0
     );
-    assert_eq!(sandbox.exec("ls /dir").await.stdout, "moved\n");
+    assert_eq!(sandbox.exec("ls /workspace/leaf///").await.stdout, "leaf\n");
+    assert_eq!(
+        sandbox
+            .exec("cp /workspace/leaf/// /workspace/dir")
+            .await
+            .exit_code,
+        0
+    );
+    assert_eq!(
+        sandbox
+            .exec("mv /workspace/dir/leaf/// /workspace/dir/moved")
+            .await
+            .exit_code,
+        0
+    );
+    assert_eq!(sandbox.exec("ls /workspace/dir").await.stdout, "moved\n");
 }
 
 #[tokio::test]
@@ -360,13 +404,16 @@ async fn limits_truncate_output_and_surface_vfs_quota_errors() {
     assert!(result.stdout.contains("output truncated"));
 
     let tiny = Sandbox::builder()
-        .vfs(InMemoryVfs::new(VfsQuota {
-            max_bytes: 3,
-            max_files: 4,
-            max_file_size: 3,
-        }))
+        .mount(
+            "workspace",
+            InMemoryVfs::new(VfsQuota {
+                max_bytes: 3,
+                max_files: 4,
+                max_file_size: 3,
+            }),
+        )
         .build();
-    let quota = tiny.exec("echo abcdef > /file").await;
+    let quota = tiny.exec("echo abcdef > /workspace/file").await;
     assert_ne!(quota.exit_code, 0);
     assert!(quota.stderr.contains("No space left on device"));
 }
@@ -409,28 +456,36 @@ async fn redirects_follow_bash_fd_order_and_preflight_timing() {
         })
         .build();
 
-    let split = sandbox.exec("both 2>&1 > /out").await;
+    let split = sandbox.exec("both 2>&1 > /workspace/out").await;
     assert_eq!(split.exit_code, 0);
     assert_eq!(split.stdout, "err\n");
-    assert_eq!(sandbox.exec("cat /out").await.stdout, "out\n");
+    assert_eq!(sandbox.exec("cat /workspace/out").await.stdout, "out\n");
 
-    let joined = sandbox.exec("both > /joined 2>&1").await;
+    let joined = sandbox.exec("both > /workspace/joined 2>&1").await;
     assert_eq!(joined.exit_code, 0);
     assert_eq!(joined.stdout, "");
-    assert_eq!(sandbox.exec("cat /joined").await.stdout, "out\nerr\n");
+    assert_eq!(
+        sandbox.exec("cat /workspace/joined").await.stdout,
+        "out\nerr\n"
+    );
 
-    assert_eq!(sandbox.exec("both 2> /err").await.exit_code, 0);
-    assert_eq!(sandbox.exec("both 2>> /err").await.exit_code, 0);
-    assert_eq!(sandbox.exec("cat /err").await.stdout, "err\nerr\n");
+    assert_eq!(sandbox.exec("both 2> /workspace/err").await.exit_code, 0);
+    assert_eq!(sandbox.exec("both 2>> /workspace/err").await.exit_code, 0);
+    assert_eq!(
+        sandbox.exec("cat /workspace/err").await.stdout,
+        "err\nerr\n"
+    );
 
-    let unsupported_fd = sandbox.exec("both 3> /bad").await;
+    let unsupported_fd = sandbox.exec("both 3> /workspace/bad").await;
     assert_eq!(unsupported_fd.exit_code, 1);
     assert!(unsupported_fd.stderr.contains("Invalid argument"));
 
-    let missing_input = sandbox.exec("echo ran > /preflight < /missing").await;
+    let missing_input = sandbox
+        .exec("echo ran > /workspace/preflight < /workspace/missing")
+        .await;
     assert_eq!(missing_input.exit_code, 1);
     assert!(missing_input.stderr.contains("No such file or directory"));
-    assert_eq!(sandbox.exec("cat /preflight").await.stdout, "");
+    assert_eq!(sandbox.exec("cat /workspace/preflight").await.stdout, "");
 }
 
 #[tokio::test]
@@ -438,16 +493,20 @@ async fn redirect_setup_failures_close_opened_handles() {
     // A later redirect failure must clean up earlier input handles and output sinks.
     let input_vfs = Arc::new(TrackingVfs::default());
     input_vfs.write_seed("/input", b"hello\n");
-    let input_sandbox = Sandbox::builder().vfs_arc(input_vfs.clone()).build();
+    let input_sandbox = Sandbox::builder()
+        .mount_arc("workspace", input_vfs.clone())
+        .build();
 
-    let input_failure = input_sandbox.exec("cat < /input > /missing/out").await;
+    let input_failure = input_sandbox
+        .exec("cat < /workspace/input > /workspace/missing/out")
+        .await;
     assert_ne!(input_failure.exit_code, 0);
     assert_eq!(input_vfs.live_handles(), 0);
 
     let output_vfs = Arc::new(TrackingVfs::default());
     output_vfs.fail_second_open_for("/stderr");
     let output_sandbox = Sandbox::builder()
-        .vfs_arc(output_vfs.clone())
+        .mount_arc("workspace", output_vfs.clone())
         .command("both", |mut ctx| async move {
             ctx.stdout.write_all(b"out\n").await.expect("write stdout");
             ctx.stderr.write_all(b"err\n").await.expect("write stderr");
@@ -455,7 +514,9 @@ async fn redirect_setup_failures_close_opened_handles() {
         })
         .build();
 
-    let output_failure = output_sandbox.exec("both > /stdout 2> /stderr").await;
+    let output_failure = output_sandbox
+        .exec("both > /workspace/stdout 2> /workspace/stderr")
+        .await;
     assert_ne!(output_failure.exit_code, 0);
     assert_eq!(output_vfs.live_handles(), 0);
 }
@@ -469,9 +530,12 @@ async fn shell_field_splitting_redirect_expansion_and_env_persist() {
     assert_eq!(sandbox.exec("X=' '").await.exit_code, 0);
     assert_eq!(sandbox.exec("echo \"1\"$X\"2\"").await.stdout, "1 2\n");
 
-    assert_eq!(sandbox.exec("OUT=/var-target").await.exit_code, 0);
+    assert_eq!(sandbox.exec("OUT=/workspace/var-target").await.exit_code, 0);
     assert_eq!(sandbox.exec("echo redirected > $OUT").await.exit_code, 0);
-    assert_eq!(sandbox.exec("cat /var-target").await.stdout, "redirected\n");
+    assert_eq!(
+        sandbox.exec("cat /workspace/var-target").await.stdout,
+        "redirected\n"
+    );
 
     assert_eq!(sandbox.exec("export KEEP=1").await.exit_code, 0);
     assert_eq!(sandbox.exec("echo $KEEP").await.stdout, "1\n");
@@ -490,17 +554,23 @@ async fn shell_field_splitting_redirect_expansion_and_env_persist() {
 async fn cd_updates_session_pwd_and_uses_home() {
     // Persistent mode keeps cwd/PWD updates between exec calls.
     let sandbox = Sandbox::builder()
-        .env("HOME", "/home")
+        .env("HOME", "/workspace/home")
         .persist_session(true)
         .build();
 
-    assert_eq!(sandbox.exec("mkdir -p /home /tmp").await.exit_code, 0);
-    assert_eq!(sandbox.exec("cd /tmp").await.exit_code, 0);
-    assert_eq!(sandbox.exec("echo $PWD").await.stdout, "/tmp\n");
+    assert_eq!(
+        sandbox
+            .exec("mkdir -p /workspace/home /workspace/tmp")
+            .await
+            .exit_code,
+        0
+    );
+    assert_eq!(sandbox.exec("cd /workspace/tmp").await.exit_code, 0);
+    assert_eq!(sandbox.exec("echo $PWD").await.stdout, "/workspace/tmp\n");
     assert_eq!(sandbox.exec("cd").await.exit_code, 0);
     assert_eq!(
         sandbox.exec("pwd; echo $PWD").await.stdout,
-        "/home\n/home\n"
+        "/workspace/home\n/workspace/home\n"
     );
 
     let no_home = Sandbox::builder().build();
@@ -510,7 +580,7 @@ async fn cd_updates_session_pwd_and_uses_home() {
 
     let after_failed_cd = sandbox.exec("cd /missing; pwd; echo $PWD").await;
     assert_eq!(after_failed_cd.exit_code, 0);
-    assert_eq!(after_failed_cd.stdout, "/home\n/home\n");
+    assert_eq!(after_failed_cd.stdout, "/workspace/home\n/workspace/home\n");
 }
 
 #[tokio::test]
@@ -519,9 +589,12 @@ async fn default_execs_discard_session_mutations_but_keep_vfs_changes() {
     // shared so files created by one exec are visible to later execs.
     let sandbox = Sandbox::builder().build();
 
-    assert_eq!(sandbox.exec("mkdir /work").await.exit_code, 0);
-    assert_eq!(sandbox.exec("cd /work").await.exit_code, 0);
-    assert_eq!(sandbox.exec("pwd; echo $PWD").await.stdout, "/\n/\n");
+    assert_eq!(sandbox.exec("mkdir /workspace/work").await.exit_code, 0);
+    assert_eq!(sandbox.exec("cd /workspace/work").await.exit_code, 0);
+    assert_eq!(
+        sandbox.exec("pwd; echo $PWD").await.stdout,
+        "/workspace\n/workspace\n"
+    );
 
     assert_eq!(sandbox.exec("export FOO=bar").await.exit_code, 0);
     assert_eq!(sandbox.exec("FOO=baz").await.exit_code, 0);
@@ -530,8 +603,17 @@ async fn default_execs_discard_session_mutations_but_keep_vfs_changes() {
     assert_eq!(sandbox.exec("false").await.exit_code, 1);
     assert_eq!(sandbox.exec("echo status=$?").await.stdout, "status=0\n");
 
-    assert_eq!(sandbox.exec("echo persisted > /file").await.exit_code, 0);
-    assert_eq!(sandbox.exec("cat /file").await.stdout, "persisted\n");
+    assert_eq!(
+        sandbox
+            .exec("echo persisted > /workspace/file")
+            .await
+            .exit_code,
+        0
+    );
+    assert_eq!(
+        sandbox.exec("cat /workspace/file").await.stdout,
+        "persisted\n"
+    );
 }
 
 #[tokio::test]
@@ -540,8 +622,14 @@ async fn persist_session_opt_in_keeps_cwd_env_and_status() {
     // want one logical shell across multiple exec calls.
     let sandbox = Sandbox::builder().persist_session(true).build();
 
-    assert_eq!(sandbox.exec("mkdir /work && cd /work").await.exit_code, 0);
-    assert_eq!(sandbox.exec("pwd").await.stdout, "/work\n");
+    assert_eq!(
+        sandbox
+            .exec("mkdir /workspace/work && cd /workspace/work")
+            .await
+            .exit_code,
+        0
+    );
+    assert_eq!(sandbox.exec("pwd").await.stdout, "/workspace/work\n");
     assert_eq!(sandbox.exec("export FOO=bar").await.exit_code, 0);
     assert_eq!(sandbox.exec("echo $FOO").await.stdout, "bar\n");
     assert_eq!(sandbox.exec("false").await.exit_code, 1);
@@ -572,16 +660,21 @@ async fn slow_vfs_dispatch_uses_blocking_threads() {
     // On a current-thread runtime, inline sleeping VFS calls would serialize
     // concurrent execs; spawn_blocking lets both touch operations overlap.
     let vfs = Arc::new(SleepingVfs::new(Duration::from_millis(75)));
-    let sandbox = Arc::new(Sandbox::builder().vfs_arc(vfs).build());
+    let sandbox = Arc::new(Sandbox::builder().mount_arc("workspace", vfs).build());
 
     let start = Instant::now();
-    let tasks: Vec<_> = ["/a", "/b", "/c", "/d"]
-        .into_iter()
-        .map(|path| {
-            let sandbox = Arc::clone(&sandbox);
-            tokio::spawn(async move { sandbox.exec(&format!("touch {path}")).await })
-        })
-        .collect();
+    let tasks: Vec<_> = [
+        "/workspace/a",
+        "/workspace/b",
+        "/workspace/c",
+        "/workspace/d",
+    ]
+    .into_iter()
+    .map(|path| {
+        let sandbox = Arc::clone(&sandbox);
+        tokio::spawn(async move { sandbox.exec(&format!("touch {path}")).await })
+    })
+    .collect();
     for task in tasks {
         assert_eq!(task.await.expect("touch task").exit_code, 0);
     }

--- a/tests/streaming.rs
+++ b/tests/streaming.rs
@@ -17,11 +17,13 @@ async fn head_stops_generated_vfs_after_small_prefix() {
     // Proves early downstream exit closes the pipe before the virtual GiB-scale
     // input is fully read.
     let vfs = Arc::new(GeneratingVfs::new(4 * 1024 * 1024 * 1024));
-    let sandbox = Sandbox::builder().vfs_arc(vfs.clone()).build();
+    let sandbox = Sandbox::builder()
+        .mount_arc("workspace", vfs.clone())
+        .build();
 
     let result = tokio::time::timeout(
         Duration::from_secs(2),
-        sandbox.exec("cat /huge | head -n 1"),
+        sandbox.exec("cat /workspace/huge | head -n 1"),
     )
     .await
     .expect("pipeline should not deadlock");
@@ -54,18 +56,23 @@ async fn full_scan_streams_data_larger_than_pipe_capacity() {
     // whole-file materialization in the VFS.
     let size = 64 * 1024 * 1024;
     let vfs = Arc::new(GeneratingVfs::new(size));
-    let sandbox = Sandbox::builder().vfs_arc(vfs.clone()).build();
+    let sandbox = Sandbox::builder()
+        .mount_arc("workspace", vfs.clone())
+        .build();
 
-    let wc = tokio::time::timeout(Duration::from_secs(5), sandbox.exec("wc -c < /huge"))
-        .await
-        .expect("wc should finish");
+    let wc = tokio::time::timeout(
+        Duration::from_secs(5),
+        sandbox.exec("wc -c < /workspace/huge"),
+    )
+    .await
+    .expect("wc should finish");
     assert_eq!(wc.exit_code, 0);
     assert_eq!(wc.stdout.trim(), size.to_string());
 
     vfs.reset_served();
     let grep = tokio::time::timeout(
         Duration::from_secs(5),
-        sandbox.exec("grep -c pattern /huge"),
+        sandbox.exec("grep -c pattern /workspace/huge"),
     )
     .await
     .expect("grep should finish");
@@ -80,11 +87,16 @@ async fn redirect_write_streams_to_vfs_file() {
     // runs, not accumulated as a command-sized buffer first.
     let size = 8 * 1024 * 1024;
     let vfs = Arc::new(GeneratingVfs::new(size));
-    let sandbox = Sandbox::builder().vfs_arc(vfs.clone()).build();
+    let sandbox = Sandbox::builder()
+        .mount_arc("workspace", vfs.clone())
+        .build();
 
-    let result = tokio::time::timeout(Duration::from_secs(5), sandbox.exec("cat /huge > /out"))
-        .await
-        .expect("redirect should finish");
+    let result = tokio::time::timeout(
+        Duration::from_secs(5),
+        sandbox.exec("cat /workspace/huge > /workspace/out"),
+    )
+    .await
+    .expect("redirect should finish");
     assert_eq!(result.exit_code, 0);
     assert!(result.stdout.is_empty());
     assert_eq!(vfs.stat("/out").expect("out stat").len, size);
@@ -105,11 +117,13 @@ async fn deadlock_regressions_complete_under_timeout() {
     // Covers fast producer with slow/early consumers, a middle stage exiting
     // immediately, and command-budget rejection before a pipeline is spawned.
     let vfs = Arc::new(GeneratingVfs::new(16 * 1024 * 1024));
-    let sandbox = Sandbox::builder().vfs_arc(vfs.clone()).build();
+    let sandbox = Sandbox::builder()
+        .mount_arc("workspace", vfs.clone())
+        .build();
 
     let head = tokio::time::timeout(
         Duration::from_secs(2),
-        sandbox.exec("cat /huge | head -n 10"),
+        sandbox.exec("cat /workspace/huge | head -n 10"),
     )
     .await
     .expect("head pipeline should not deadlock");
@@ -117,7 +131,7 @@ async fn deadlock_regressions_complete_under_timeout() {
 
     let fail_mid = tokio::time::timeout(
         Duration::from_secs(2),
-        sandbox.exec("cat /huge | false | wc -c"),
+        sandbox.exec("cat /workspace/huge | false | wc -c"),
     )
     .await
     .expect("failed middle stage should not deadlock");
@@ -125,15 +139,18 @@ async fn deadlock_regressions_complete_under_timeout() {
     assert_eq!(fail_mid.stdout.trim(), "0");
 
     let limited = Sandbox::builder()
-        .vfs_arc(vfs)
+        .mount_arc("workspace", vfs)
         .limits(Limits {
             max_commands: 1,
             ..Limits::default()
         })
         .build();
-    let limit = tokio::time::timeout(Duration::from_secs(2), limited.exec("cat /huge | wc -c"))
-        .await
-        .expect("limit hit should not spawn a stuck pipeline");
+    let limit = tokio::time::timeout(
+        Duration::from_secs(2),
+        limited.exec("cat /workspace/huge | wc -c"),
+    )
+    .await
+    .expect("limit hit should not spawn a stuck pipeline");
     assert_eq!(limit.exit_code, 125);
     assert!(limit.stderr.contains("maximum command count exceeded"));
 }
@@ -144,14 +161,14 @@ async fn output_cap_truncates_while_draining_stream() {
     let size = 8 * 1024 * 1024;
     let vfs = Arc::new(GeneratingVfs::new(size));
     let sandbox = Sandbox::builder()
-        .vfs_arc(vfs.clone())
+        .mount_arc("workspace", vfs.clone())
         .limits(Limits {
             stdout_bytes: 1024,
             ..Limits::default()
         })
         .build();
 
-    let result = tokio::time::timeout(Duration::from_secs(5), sandbox.exec("cat /huge"))
+    let result = tokio::time::timeout(Duration::from_secs(5), sandbox.exec("cat /workspace/huge"))
         .await
         .expect("capped output should finish");
     assert_eq!(result.exit_code, 0);
@@ -167,11 +184,11 @@ async fn redirected_stdin_in_later_stage_closes_upstream_pipe() {
     // upstream pipe reader must close instead of keeping the producer blocked.
     let vfs = Arc::new(GeneratingVfs::new(16 * 1024 * 1024));
     vfs.write_inner("/small", b"abc");
-    let sandbox = Sandbox::builder().vfs_arc(vfs).build();
+    let sandbox = Sandbox::builder().mount_arc("workspace", vfs).build();
 
     let result = tokio::time::timeout(
         Duration::from_secs(2),
-        sandbox.exec("cat /huge | wc -c < /small"),
+        sandbox.exec("cat /workspace/huge | wc -c < /workspace/small"),
     )
     .await
     .expect("redirected later stage should not deadlock");
@@ -194,10 +211,10 @@ async fn pipeline_shell_builtins_do_not_mutate_session_but_still_write_stdout() 
     // but builtins like `export` still execute and can feed the pipe.
     let sandbox = Sandbox::builder().build();
 
-    assert_eq!(sandbox.exec("mkdir /sub").await.exit_code, 0);
-    let cd = sandbox.exec("cd /sub | cat; pwd").await;
+    assert_eq!(sandbox.exec("mkdir /workspace/sub").await.exit_code, 0);
+    let cd = sandbox.exec("cd /workspace/sub | cat; pwd").await;
     assert_eq!(cd.exit_code, 0);
-    assert_eq!(cd.stdout, "/\n");
+    assert_eq!(cd.stdout, "/workspace\n");
 
     let assignment = sandbox.exec("FOO=bar | cat; echo $FOO").await;
     assert_eq!(assignment.exit_code, 0);
@@ -227,14 +244,14 @@ async fn per_stage_redirect_failure_does_not_abort_pipeline() {
     // EOF on their pipe and determine the pipeline status.
     let sandbox = Sandbox::builder().build();
 
-    let result = sandbox.exec("cat < /missing | wc -l").await;
+    let result = sandbox.exec("cat < /workspace/missing | wc -l").await;
 
     assert_eq!(result.exit_code, 0);
     assert_eq!(result.stdout.trim(), "0");
     assert!(
         result
             .stderr
-            .contains("cat: /missing: No such file or directory")
+            .contains("cat: /workspace/missing: No such file or directory")
     );
 }
 
@@ -244,7 +261,7 @@ async fn timeout_aborts_spawned_pipeline_tasks() {
     // timeout returns; abort-on-drop prevents that late mutation.
     let vfs = Arc::new(InMemoryVfs::default());
     let sandbox = Sandbox::builder()
-        .vfs_arc(vfs.clone())
+        .mount_arc("workspace", vfs.clone())
         .limits(Limits {
             wall_time: Duration::from_millis(50),
             ..Limits::default()
@@ -252,7 +269,7 @@ async fn timeout_aborts_spawned_pipeline_tasks() {
         .command("latewrite", |ctx| async move {
             tokio::time::sleep(Duration::from_millis(200)).await;
             ctx.fs
-                .write_file("/late", b"too late", false)
+                .write_file("/workspace/late", b"too late", false)
                 .await
                 .expect("late write");
             tinysandbox::sandbox::CommandResult::success()
@@ -276,15 +293,20 @@ async fn mid_stream_vfs_read_errors_are_reported() {
     // The reader must surface failures after already returning some bytes; EOF
     // would make these commands falsely succeed with truncated input.
     let vfs = Arc::new(GeneratingVfs::new(4 * 1024 * 1024).fail_after(128 * 1024));
-    let sandbox = Sandbox::builder().vfs_arc(vfs.clone()).build();
+    let sandbox = Sandbox::builder()
+        .mount_arc("workspace", vfs.clone())
+        .build();
 
-    let wc = sandbox.exec("wc -c < /huge").await;
+    let wc = sandbox.exec("wc -c < /workspace/huge").await;
     assert_eq!(wc.exit_code, 1);
     assert!(wc.stderr.contains("wc: -: Invalid argument"));
 
-    let cat = sandbox.exec("cat /huge > /out").await;
+    let cat = sandbox.exec("cat /workspace/huge > /workspace/out").await;
     assert_eq!(cat.exit_code, 1);
-    assert!(cat.stderr.contains("cat: /huge: Invalid argument"));
+    assert!(
+        cat.stderr
+            .contains("cat: /workspace/huge: Invalid argument")
+    );
     assert!(vfs.stat("/out").expect("partial out exists").len < 4 * 1024 * 1024);
 }
 
@@ -293,28 +315,37 @@ async fn line_tools_report_mid_stream_vfs_read_errors() {
     // Line-oriented commands must report read errors that happen after partial
     // input, not silently treat the stream as EOF.
     let vfs = Arc::new(GeneratingVfs::new(4 * 1024 * 1024).fail_after(128 * 1024));
-    let sandbox = Sandbox::builder().vfs_arc(vfs).build();
+    let sandbox = Sandbox::builder().mount_arc("workspace", vfs).build();
 
-    let sed = sandbox.exec("sed 's/p/q/' /huge").await;
+    let sed = sandbox.exec("sed 's/p/q/' /workspace/huge").await;
     assert_eq!(sed.exit_code, 2);
-    assert!(sed.stderr.contains("sed: /huge: Invalid argument"));
+    assert!(
+        sed.stderr
+            .contains("sed: /workspace/huge: Invalid argument")
+    );
 
-    let head = sandbox.exec("head -n 100000 /huge").await;
+    let head = sandbox.exec("head -n 100000 /workspace/huge").await;
     assert_eq!(head.exit_code, 1);
-    assert!(head.stderr.contains("head: /huge: Invalid argument"));
+    assert!(
+        head.stderr
+            .contains("head: /workspace/huge: Invalid argument")
+    );
 
-    let tail = sandbox.exec("tail /huge").await;
+    let tail = sandbox.exec("tail /workspace/huge").await;
     assert_eq!(tail.exit_code, 1);
-    assert!(tail.stderr.contains("tail: /huge: Invalid argument"));
+    assert!(
+        tail.stderr
+            .contains("tail: /workspace/huge: Invalid argument")
+    );
 }
 
 #[tokio::test]
 async fn grep_closed_pipe_stops_without_stderr() {
     // GNU grep exits silently on SIGPIPE when a downstream command stops early.
     let vfs = Arc::new(GeneratingVfs::new(8 * 1024 * 1024));
-    let sandbox = Sandbox::builder().vfs_arc(vfs).build();
+    let sandbox = Sandbox::builder().mount_arc("workspace", vfs).build();
 
-    let result = sandbox.exec("grep p /huge | head -n 1").await;
+    let result = sandbox.exec("grep p /workspace/huge | head -n 1").await;
 
     assert_eq!(result.exit_code, 0);
     assert!(result.stderr.is_empty());
@@ -385,16 +416,16 @@ async fn long_no_newline_streams_are_bounded() {
     // commands reject the same input before buffering it all.
     let size = 2 * 1024 * 1024;
     let vfs = Arc::new(GeneratingVfs::new_without_newlines(size));
-    let sandbox = Sandbox::builder().vfs_arc(vfs).build();
+    let sandbox = Sandbox::builder().mount_arc("workspace", vfs).build();
 
-    let cat = sandbox.exec("cat /huge | wc -c").await;
+    let cat = sandbox.exec("cat /workspace/huge | wc -c").await;
     assert_eq!(cat.exit_code, 0);
     assert_eq!(cat.stdout.trim(), size.to_string());
     assert!(cat.stderr.is_empty());
 
-    let grep = sandbox.exec("grep z /huge").await;
+    let grep = sandbox.exec("grep z /workspace/huge").await;
     assert_eq!(grep.exit_code, 2);
-    assert!(grep.stderr.contains("grep: /huge: line too long"));
+    assert!(grep.stderr.contains("grep: /workspace/huge: line too long"));
 }
 
 #[tokio::test]
@@ -405,11 +436,20 @@ async fn wc_word_count_uses_c_locale_ascii_separators() {
     write_file(vfs.as_ref(), "/nbsp", "a\u{00a0}b\n".as_bytes());
     write_file(vfs.as_ref(), "/u2028", "a\u{2028}b\n".as_bytes());
     write_file(vfs.as_ref(), "/space", b"a b\n");
-    let sandbox = Sandbox::builder().vfs_arc(vfs).build();
+    let sandbox = Sandbox::builder().mount_arc("workspace", vfs).build();
 
-    assert_eq!(sandbox.exec("wc -w /nbsp").await.stdout.trim(), "1 /nbsp");
-    assert_eq!(sandbox.exec("wc -w /u2028").await.stdout.trim(), "1 /u2028");
-    assert_eq!(sandbox.exec("wc -w /space").await.stdout.trim(), "2 /space");
+    assert_eq!(
+        sandbox.exec("wc -w /workspace/nbsp").await.stdout.trim(),
+        "1 /workspace/nbsp"
+    );
+    assert_eq!(
+        sandbox.exec("wc -w /workspace/u2028").await.stdout.trim(),
+        "1 /workspace/u2028"
+    );
+    assert_eq!(
+        sandbox.exec("wc -w /workspace/space").await.stdout.trim(),
+        "2 /workspace/space"
+    );
 }
 
 fn write_file(vfs: &dyn Vfs, path: &str, data: &[u8]) {

--- a/tests/vfs_s3.rs
+++ b/tests/vfs_s3.rs
@@ -268,11 +268,11 @@ async fn s3_compatible_adapter_vfs_and_sandbox_end_to_end() {
 
     let sandbox_vfs =
         S3Vfs::new(client, &config.bucket, Some(&config.prefix)).expect("construct sandbox S3 VFS");
-    let sandbox = Sandbox::builder().vfs(sandbox_vfs).build();
+    let sandbox = Sandbox::builder().mount("workspace", sandbox_vfs).build();
     assert_eq!(
         sandbox
             .fs()
-            .read_file("/nested/data.txt")
+            .read_file("/workspace/nested/data.txt")
             .await
             .expect("Sandbox::fs read"),
         NESTED
@@ -280,30 +280,30 @@ async fn s3_compatible_adapter_vfs_and_sandbox_end_to_end() {
     let first_fs = sandbox.fs();
     let second_fs = sandbox.fs();
     let (first, second) = tokio::join!(
-        first_fs.read_file("/alpha.txt"),
-        second_fs.read_file("/nested/data.txt")
+        first_fs.read_file("/workspace/alpha.txt"),
+        second_fs.read_file("/workspace/nested/data.txt")
     );
     assert_eq!(first.expect("first simultaneous read"), ALPHA);
     assert_eq!(second.expect("second simultaneous read"), NESTED);
 
-    let head = sandbox.exec("cat /large.txt | head -n 1").await;
+    let head = sandbox.exec("cat /workspace/large.txt | head -n 1").await;
     assert_eq!(head.exit_code, 0, "{}", head.stderr);
     assert_eq!(head.stdout, "first record\n");
-    let grep = sandbox.exec("grep needle /nested/data.txt").await;
+    let grep = sandbox.exec("grep needle /workspace/nested/data.txt").await;
     assert_eq!(grep.exit_code, 0, "{}", grep.stderr);
     assert_eq!(grep.stdout, "nested needle\n");
-    let wc = sandbox.exec("wc -c < /large.txt").await;
+    let wc = sandbox.exec("wc -c < /workspace/large.txt").await;
     assert_eq!(wc.exit_code, 0, "{}", wc.stderr);
     assert_eq!(wc.stdout.trim(), large.len().to_string());
 
-    let redirect = sandbox.exec("echo forbidden > /new.txt").await;
+    let redirect = sandbox.exec("echo forbidden > /workspace/new.txt").await;
     assert_ne!(redirect.exit_code, 0);
     assert!(
         redirect.stderr.contains("Permission denied"),
         "{}",
         redirect.stderr
     );
-    let touch = sandbox.exec("touch /new.txt").await;
+    let touch = sandbox.exec("touch /workspace/new.txt").await;
     assert_ne!(touch.exit_code, 0);
     assert!(
         touch.stderr.contains("Permission denied"),
@@ -315,7 +315,7 @@ async fn s3_compatible_adapter_vfs_and_sandbox_end_to_end() {
     {
         let js = sandbox
             .exec(
-                r#"js -e "const fs=require('fs'); console.log(fs.readFileSync('/alpha.txt','utf8').trim())""#,
+                r#"js -e "const fs=require('fs'); console.log(fs.readFileSync('/workspace/alpha.txt','utf8').trim())""#,
             )
             .await;
         assert_eq!(js.exit_code, 0, "{}", js.stderr);

--- a/tinysandbox-node/README.md
+++ b/tinysandbox-node/README.md
@@ -22,9 +22,9 @@ console.log(result.stdout)
 
 - A bash-like shell subset with pipelines, redirects, variables, and session state.
 - Built-in commands such as `cat`, `grep`, `head`, `tail`, `sort`, `uniq`, `wc`, `sed`, `jq`, `ls`, `cp`, `mv`, `rm`, and `mkdir`.
-- A quota-enforced virtual filesystem with direct host APIs and JavaScript-backed VFS adapters.
-- An optional local directory VFS (`localVfs: { root, quota? }`, Unix only) that persists the sandbox filesystem under a host directory with strict path containment (`..` clamped at the root, symlinks never followed). Quota usage can be rebaselined from the host via `sandbox.refreshLocalVfs()` (rescan) or `sandbox.setLocalVfsUsage({ usedBytes, fileCount })` (push).
-- A built-in read-only S3 VFS that exposes one bucket/key prefix as `/` and performs bounded range reads instead of downloading whole objects.
+- Static top-level filesystem mounts backed by memory, local directories, S3, or JavaScript VFS adapters. The default is an in-memory `/workspace`. `ls /` lists every mount plus `/bin`.
+- Local directory mounts (Unix only) with strict path containment and per-mount quotas. Usage can be rebaselined with `sandbox.refreshLocalVfs(mount)` or `sandbox.setLocalVfsUsage(mount, usage)`.
+- Read-only S3 mounts that expose bucket/key prefixes and perform bounded range reads instead of downloading whole objects.
 - A sandboxed `js` command with a Node-compatible synchronous `fs` subset, `require`, `Buffer`, `process`, and `console`; expose JS-facing custom host functionality as syscalls.
 - Limits and metrics for wall time, output size, command timings, pipe bytes, jq input bytes, and wasm memory. jq input bytes and JSON nesting are capped before evaluation, and the jq filter program text (not input data) is capped on size, nesting, and syntax complexity; jq filter evaluation has the limitations documented in the repository README.
 
@@ -34,18 +34,23 @@ console.log(result.stdout)
 import { Sandbox } from '@tinysandbox/tinysandbox'
 
 const sandbox = new Sandbox({
-  s3Vfs: {
-    bucket: 'agent-inputs',
-    prefix: 'tenant-42/current',
-    region: 'us-east-1',
-    // Optional for S3-compatible APIs:
-    // endpointUrl: 'http://127.0.0.1:9000',
-    // forcePathStyle: true,
-    // credentials: { accessKeyId: '...', secretAccessKey: '...' }
-  }
+  mounts: {
+    workspace: { type: 'memory' },
+    input: {
+      type: 's3',
+      bucket: 'agent-inputs',
+      prefix: 'tenant-42/current',
+      region: 'us-east-1',
+      // Optional for S3-compatible APIs:
+      // endpointUrl: 'http://127.0.0.1:9000',
+      // forcePathStyle: true,
+      // credentials: { accessKeyId: '...', secretAccessKey: '...' }
+    }
+  },
+  cwd: '/workspace'
 })
 
-const result = await sandbox.exec('cat /large.log | head -n 1')
+const result = await sandbox.exec('cat /input/large.log | head -n 1')
 ```
 
 When region or credentials are omitted, the AWS SDK default provider chains

--- a/tinysandbox-node/__test__/local_vfs.test.mjs
+++ b/tinysandbox-node/__test__/local_vfs.test.mjs
@@ -19,52 +19,52 @@ async function withScratchDir(fn) {
   }
 }
 
-test('localVfs persists sandbox writes to the host directory', { skip: !isUnix }, async () => {
+test('local mount persists sandbox writes to the host directory', { skip: !isUnix }, async () => {
   await withScratchDir(async (root) => {
     await writeFile(join(root, 'seeded.txt'), 'from host')
-    const sandbox = new Sandbox({ localVfs: { root } })
+    const sandbox = new Sandbox({ mounts: { workspace: { type: 'local', root } } })
 
-    const seeded = await sandbox.exec('cat /seeded.txt')
+    const seeded = await sandbox.exec('cat /workspace/seeded.txt')
     assert.equal(seeded.exitCode, 0, seeded.stderr)
     assert.equal(seeded.stdout, 'from host')
 
-    const result = await sandbox.exec('mkdir /work && echo hello > /work/out.txt')
+    const result = await sandbox.exec('mkdir /workspace/work && echo hello > /workspace/work/out.txt')
     assert.equal(result.exitCode, 0, result.stderr)
     assert.equal(await readFile(join(root, 'work', 'out.txt'), 'utf8'), 'hello\n')
   })
 })
 
-test('localVfs clamps traversal at the root and refuses symlinks', { skip: !isUnix }, async () => {
+test('local mount clamps traversal at the root and refuses symlinks', { skip: !isUnix }, async () => {
   await withScratchDir(async (root, parent) => {
     await writeFile(join(parent, 'secret.txt'), 'top secret')
     await symlink(join(parent, 'secret.txt'), join(root, 'link'))
-    const sandbox = new Sandbox({ localVfs: { root } })
+    const sandbox = new Sandbox({ mounts: { workspace: { type: 'local', root } } })
 
-    // "/../secret.txt" resolves inside the root, not to the sibling file.
-    const traversal = await sandbox.exec('cat /../secret.txt')
+    // Parent traversal cannot escape the mount namespace to the host sibling.
+    const traversal = await sandbox.exec('cat /workspace/../../secret.txt')
     assert.notEqual(traversal.exitCode, 0)
 
-    const escape = await sandbox.exec('echo contained > /../escape.txt')
+    const escape = await sandbox.exec('echo contained > /workspace/../workspace/escape.txt')
     assert.equal(escape.exitCode, 0, escape.stderr)
     assert.equal(await readFile(join(root, 'escape.txt'), 'utf8'), 'contained\n')
     assert.ok(!existsSync(join(parent, 'escape.txt')))
 
     // Symlinks are invisible: unreadable, and writes never follow them.
-    const readLink = await sandbox.exec('cat /link')
+    const readLink = await sandbox.exec('cat /workspace/link')
     assert.notEqual(readLink.exitCode, 0)
-    const writeLink = await sandbox.exec('echo clobber > /link')
+    const writeLink = await sandbox.exec('echo clobber > /workspace/link')
     assert.notEqual(writeLink.exitCode, 0)
     assert.equal(await readFile(join(parent, 'secret.txt'), 'utf8'), 'top secret')
   })
 })
 
-test('localVfs enforces quota and reports stats', { skip: !isUnix }, async () => {
+test('local mount enforces quota and reports stats', { skip: !isUnix }, async () => {
   await withScratchDir(async (root) => {
-    const sandbox = new Sandbox({ localVfs: { root, quota: { maxBytes: 8 } } })
+    const sandbox = new Sandbox({ mounts: { workspace: { type: 'local', root, quota: { maxBytes: 8 } } } })
 
-    await sandbox.fs.writeFile('/data.bin', Buffer.alloc(8, 1))
+    await sandbox.fs.writeFile('/workspace/data.bin', Buffer.alloc(8, 1))
     await assert.rejects(
-      () => sandbox.fs.appendFile('/data.bin', Buffer.from('x')),
+      () => sandbox.fs.appendFile('/workspace/data.bin', Buffer.from('x')),
       (err) => {
         assert.equal(err.code, 'ENOSPC')
         return true
@@ -77,10 +77,10 @@ test('localVfs enforces quota and reports stats', { skip: !isUnix }, async () =>
   })
 })
 
-test('localVfs usage can be refreshed and pushed from the host', { skip: !isUnix }, async () => {
+test('local mount usage can be refreshed and pushed from the host', { skip: !isUnix }, async () => {
   await withScratchDir(async (root) => {
-    const sandbox = new Sandbox({ localVfs: { root, quota: { maxBytes: 16 } } })
-    await sandbox.fs.writeFile('/a.bin', Buffer.alloc(4, 1))
+    const sandbox = new Sandbox({ mounts: { workspace: { type: 'local', root, quota: { maxBytes: 16 } } } })
+    await sandbox.fs.writeFile('/workspace/a.bin', Buffer.alloc(4, 1))
 
     // The host mutates the tree behind the sandbox's back...
     await writeFile(join(root, 'external.bin'), Buffer.alloc(6, 2))
@@ -88,44 +88,48 @@ test('localVfs usage can be refreshed and pushed from the host', { skip: !isUnix
     assert.equal(stats.vfs.usedBytes, 4)
 
     // ...and reconciles with a rescan.
-    const refreshed = await sandbox.refreshLocalVfs()
+    const refreshed = await sandbox.refreshLocalVfs('workspace')
     assert.equal(refreshed.usedBytes, 10)
     assert.equal(refreshed.fileCount, 2)
     stats = await sandbox.stats()
     assert.equal(stats.vfs.usedBytes, 10)
 
     // Pushed usage becomes the enforcement baseline.
-    sandbox.setLocalVfsUsage({ usedBytes: 16, fileCount: 2 })
+    sandbox.setLocalVfsUsage('workspace', { usedBytes: 16, fileCount: 2 })
     await assert.rejects(
-      () => sandbox.fs.appendFile('/a.bin', Buffer.from('x')),
+      () => sandbox.fs.appendFile('/workspace/a.bin', Buffer.from('x')),
       (err) => {
         assert.equal(err.code, 'ENOSPC')
         return true
       }
     )
-    sandbox.setLocalVfsUsage({ usedBytes: 10, fileCount: 2 })
-    await sandbox.fs.appendFile('/a.bin', Buffer.from('x'))
+    sandbox.setLocalVfsUsage('workspace', { usedBytes: 10, fileCount: 2 })
+    await sandbox.fs.appendFile('/workspace/a.bin', Buffer.from('x'))
 
-    assert.throws(() => sandbox.setLocalVfsUsage({ usedBytes: -1, fileCount: 0 }), /usedBytes/)
+    assert.throws(() => sandbox.setLocalVfsUsage('workspace', { usedBytes: -1, fileCount: 0 }), /usedBytes/)
 
     const plain = new Sandbox()
-    await assert.rejects(() => plain.refreshLocalVfs(), /localVfs/)
-    assert.throws(() => plain.setLocalVfsUsage({ usedBytes: 0, fileCount: 0 }), /localVfs/)
+    await assert.rejects(() => plain.refreshLocalVfs('workspace'), /not a local filesystem/)
+    assert.throws(
+      () => plain.setLocalVfsUsage('workspace', { usedBytes: 0, fileCount: 0 }),
+      /not a local filesystem/
+    )
   })
 })
 
-test('localVfs rejects invalid configuration', { skip: !isUnix }, async () => {
+test('local mount rejects invalid configuration', { skip: !isUnix }, async () => {
   await withScratchDir(async (root) => {
-    assert.throws(() => new Sandbox({ localVfs: { root: join(root, 'missing') } }), /localVfs root/)
     assert.throws(
-      () => new Sandbox({ localVfs: { root, quota: { maxBytes: -1 } } }),
+      () => new Sandbox({ mounts: { workspace: { type: 'local', root: join(root, 'missing') } } }),
+      /local mount 'workspace' root/
+    )
+    assert.throws(
+      () => new Sandbox({ mounts: { workspace: { type: 'local', root, quota: { maxBytes: -1 } } } }),
       /non-negative safe integer/
     )
-    const stubVfs = Object.fromEntries(
-      ['stat', 'readdir', 'mkdir', 'rename', 'unlink', 'rmdir', 'open', 'readAt', 'writeAt', 'truncate', 'close'].map(
-        (name) => [name, async () => ({})]
-      )
+    assert.throws(
+      () => new Sandbox({ mounts: { bin: { type: 'local', root } } }),
+      /mount name 'bin'/
     )
-    assert.throws(() => new Sandbox({ vfs: stubVfs, localVfs: { root } }), /either vfs or localVfs/)
   })
 })

--- a/tinysandbox-node/__test__/s3_vfs.test.mjs
+++ b/tinysandbox-node/__test__/s3_vfs.test.mjs
@@ -39,6 +39,10 @@ function liveOptions(prefix = requiredEnv('TINYSANDBOX_S3_TEST_PREFIX')) {
   }
 }
 
+function sandboxWithS3(options) {
+  return new Sandbox({ mounts: { input: { type: 's3', ...options } } })
+}
+
 test('S3 compatibility endpoint guard is strictly loopback-only', () => {
   for (const value of ['http://127.0.0.1:9000', 'http://localhost:1']) {
     assert.equal(isAllowedLoopbackEndpoint(value), true, value)
@@ -56,67 +60,48 @@ test('S3 compatibility endpoint guard is strictly loopback-only', () => {
   }
 })
 
-test('s3Vfs validates option shapes synchronously', () => {
-  assert.doesNotThrow(() => new Sandbox({ s3Vfs: null }))
-  assert.doesNotThrow(() => new Sandbox({ s3Vfs: undefined }))
-  assert.throws(() => new Sandbox({ s3Vfs: {} }), /s3Vfs bucket is required/)
-  assert.throws(() => new Sandbox({ s3Vfs: 42 }), /object/i)
-  assert.throws(() => new Sandbox({ s3Vfs: { bucket: '' } }), /bucket must be a nonempty string/)
-  assert.throws(() => new Sandbox({ s3Vfs: { bucket: '   ' } }), /bucket must be a nonempty string/)
-  assert.throws(() => new Sandbox({ s3Vfs: { bucket: 42 } }), /string/i)
-  assert.throws(() => new Sandbox({ s3Vfs: { bucket: 'bucket', prefix: 42 } }), /string/i)
-  assert.throws(() => new Sandbox({ s3Vfs: { bucket: 'bucket', region: '' } }), /region must be a nonempty string/)
-  assert.throws(() => new Sandbox({ s3Vfs: { bucket: 'bucket', region: 42 } }), /string/i)
-  assert.throws(() => new Sandbox({ s3Vfs: { bucket: 'bucket', endpointUrl: '' } }), /endpointUrl must be a nonempty string/)
+test('s3 mount validates option shapes synchronously', () => {
+  assert.throws(() => sandboxWithS3({}), /S3 mount bucket is required/)
+  assert.throws(() => sandboxWithS3({ bucket: '' }), /bucket must be a nonempty string/)
+  assert.throws(() => sandboxWithS3({ bucket: '   ' }), /bucket must be a nonempty string/)
+  assert.throws(() => sandboxWithS3({ bucket: 42 }), /string/i)
+  assert.throws(() => sandboxWithS3({ bucket: 'bucket', prefix: 42 }), /string/i)
+  assert.throws(() => sandboxWithS3({ bucket: 'bucket', region: '' }), /region must be a nonempty string/)
+  assert.throws(() => sandboxWithS3({ bucket: 'bucket', region: 42 }), /string/i)
+  assert.throws(() => sandboxWithS3({ bucket: 'bucket', endpointUrl: '' }), /endpointUrl must be a nonempty string/)
   assert.throws(
-    () => new Sandbox({ s3Vfs: { bucket: 'bucket', credentials: { secretAccessKey: 'secret' } } }),
+    () => sandboxWithS3({ bucket: 'bucket', credentials: { secretAccessKey: 'secret' } }),
     /accessKeyId is required/
   )
   assert.throws(
-    () => new Sandbox({ s3Vfs: { bucket: 'bucket', credentials: { accessKeyId: 'key' } } }),
+    () => sandboxWithS3({ bucket: 'bucket', credentials: { accessKeyId: 'key' } }),
     /secretAccessKey is required/
   )
   assert.throws(
-    () => new Sandbox({
-      s3Vfs: {
-        bucket: 'bucket',
-        credentials: { accessKeyId: 'key', secretAccessKey: 'secret', sessionToken: '' }
-      }
+    () => sandboxWithS3({
+      bucket: 'bucket',
+      credentials: { accessKeyId: 'key', secretAccessKey: 'secret', sessionToken: '' }
     }),
     /sessionToken must be a nonempty string/
-  )
-  assert.throws(
-    () => new Sandbox({ vfs: {}, s3Vfs: {} }),
-    /either vfs or localVfs or s3Vfs/
-  )
-  assert.throws(
-    () => new Sandbox({ localVfs: {}, s3Vfs: {} }),
-    /either vfs or localVfs or s3Vfs/
   )
 
   const accessKeyId = 'shape-test-key'
   const secretAccessKey = 'shape-test-secret'
-  assert.doesNotThrow(() => new Sandbox({
-    vfs: null,
-    localVfs: undefined,
-    s3Vfs: {
-      bucket: 'bucket',
-      prefix: null,
-      region: 'us-east-1',
-      endpointUrl: null,
-      forcePathStyle: null,
-      credentials: { accessKeyId, secretAccessKey, sessionToken: null }
-    }
+  assert.doesNotThrow(() => sandboxWithS3({
+    bucket: 'bucket',
+    prefix: null,
+    region: 'us-east-1',
+    endpointUrl: null,
+    forcePathStyle: null,
+    credentials: { accessKeyId, secretAccessKey, sessionToken: null }
   }))
-  assert.doesNotThrow(() => new Sandbox({
-    s3Vfs: { bucket: 'bucket', region: 'us-east-1', credentials: null }
-  }))
+  assert.doesNotThrow(() => sandboxWithS3({ bucket: 'bucket', region: 'us-east-1', credentials: null }))
 
   const originalRegion = process.env.AWS_REGION
   process.env.AWS_REGION = 'us-east-1'
   try {
-    assert.doesNotThrow(() => new Sandbox({
-      s3Vfs: { bucket: 'bucket', region: null, credentials: { accessKeyId, secretAccessKey } }
+    assert.doesNotThrow(() => sandboxWithS3({
+      bucket: 'bucket', region: null, credentials: { accessKeyId, secretAccessKey }
     }))
   } finally {
     if (originalRegion === undefined) delete process.env.AWS_REGION
@@ -129,41 +114,39 @@ test('custom VFS EIO errors retain their code', async () => {
     ['stat', 'readdir', 'mkdir', 'rename', 'unlink', 'rmdir', 'open', 'readAt', 'writeAt', 'truncate', 'close']
       .map((name) => [name, async () => { const error = new Error('remote I/O failed'); error.code = 'EIO'; throw error }])
   )
-  const sandbox = new Sandbox({ vfs })
-  await assert.rejects(() => sandbox.fs.stat('/x'), { code: 'EIO' })
+  const sandbox = new Sandbox({ mounts: { remote: { type: 'custom', vfs } } })
+  await assert.rejects(() => sandbox.fs.stat('/remote/x'), { code: 'EIO' })
 })
 
-test('built-in s3Vfs request failures use the normal EIO filesystem shape', async () => {
-  const sandbox = new Sandbox({
-    s3Vfs: {
-      bucket: 'bucket',
-      region: 'us-east-1',
-      endpointUrl: 'not a url',
-      forcePathStyle: true,
-      credentials: { accessKeyId: 'key', secretAccessKey: 'secret' }
-    }
+test('built-in S3 mount request failures use the normal EIO filesystem shape', async () => {
+  const sandbox = sandboxWithS3({
+    bucket: 'bucket',
+    region: 'us-east-1',
+    endpointUrl: 'not a url',
+    forcePathStyle: true,
+    credentials: { accessKeyId: 'key', secretAccessKey: 'secret' }
   })
   await assert.rejects(
-    () => sandbox.fs.stat('/x'),
+    () => sandbox.fs.stat('/input/x'),
     (error) => {
       assert.equal(error.code, 'EIO')
-      assert.match(error.message, /^EIO: \/x$/)
+      assert.match(error.message, /^EIO: \/input\/x$/)
       return true
     }
   )
 })
 
-test('s3Vfs reads a prefix through host, shell, and embedded JS APIs', { skip: !live }, async () => {
-  const sandbox = new Sandbox({ s3Vfs: liveOptions() })
+test('S3 mount reads a prefix through host, shell, and embedded JS APIs', { skip: !live }, async () => {
+  const sandbox = sandboxWithS3(liveOptions())
 
-  assert.deepEqual(await sandbox.fs.stat('/alpha.txt'), {
+  assert.deepEqual(await sandbox.fs.stat('/input/alpha.txt'), {
     fileType: 'file',
     len: 6,
     isFile: true,
     isDir: false
   })
   assert.deepEqual(
-    (await sandbox.fs.readdir('/')).map(({ name, fileType }) => [name, fileType]),
+    (await sandbox.fs.readdir('/input')).map(({ name, fileType }) => [name, fileType]),
     [
       ['alpha.txt', 'file'],
       ['empty-marker', 'directory'],
@@ -171,9 +154,9 @@ test('s3Vfs reads a prefix through host, shell, and embedded JS APIs', { skip: !
       ['nested', 'directory']
     ]
   )
-  assert.equal(String(await sandbox.fs.readFile('/nested/data.txt')), 'nested needle\nanother line\n')
+  assert.equal(String(await sandbox.fs.readFile('/input/nested/data.txt')), 'nested needle\nanother line\n')
 
-  const handle = await sandbox.fs.open('/large.txt', { read: true })
+  const handle = await sandbox.fs.open('/input/large.txt', { read: true })
   try {
     assert.equal(String(await sandbox.fs.readAt(handle, 13, 11)), 'record-0000')
   } finally {
@@ -181,63 +164,61 @@ test('s3Vfs reads a prefix through host, shell, and embedded JS APIs', { skip: !
   }
 
   const [alpha, nested] = await Promise.all([
-    sandbox.fs.readFile('/alpha.txt'),
-    sandbox.fs.readFile('/nested/data.txt')
+    sandbox.fs.readFile('/input/alpha.txt'),
+    sandbox.fs.readFile('/input/nested/data.txt')
   ])
   assert.equal(String(alpha), 'alpha\n')
   assert.equal(String(nested), 'nested needle\nanother line\n')
 
-  const head = await sandbox.exec('cat /large.txt | head -n 1')
+  const head = await sandbox.exec('cat /input/large.txt | head -n 1')
   assert.equal(head.exitCode, 0, head.stderr)
   assert.equal(head.stdout, 'first record\n')
-  const grep = await sandbox.exec('grep needle /nested/data.txt')
+  const grep = await sandbox.exec('grep needle /input/nested/data.txt')
   assert.equal(grep.exitCode, 0, grep.stderr)
   assert.equal(grep.stdout, 'nested needle\n')
-  const embedded = await sandbox.exec(`js -e 'const fs=require("fs"); console.log(fs.readFileSync("/alpha.txt","utf8").trim())'`)
+  const embedded = await sandbox.exec(`js -e 'const fs=require("fs"); console.log(fs.readFileSync("/input/alpha.txt","utf8").trim())'`)
   assert.equal(embedded.exitCode, 0, embedded.stderr)
   assert.equal(embedded.stdout, 'alpha\n')
 })
 
-test('s3Vfs rejects mutations and contains its configured prefix', { skip: !live }, async () => {
-  const sandbox = new Sandbox({ s3Vfs: liveOptions() })
+test('S3 mount rejects mutations and contains its configured prefix', { skip: !live }, async () => {
+  const sandbox = sandboxWithS3(liveOptions())
 
-  await assert.rejects(() => sandbox.fs.writeFile('/new.txt', Buffer.from('forbidden')), { code: 'EACCES' })
-  await assert.rejects(() => sandbox.fs.mkdir('/new-dir'), { code: 'EACCES' })
-  await assert.rejects(() => sandbox.fs.stat('/../root-secret.txt'), { code: 'ENOENT' })
-  assert.ok((await sandbox.fs.readdir('/')).every((entry) => !entry.name.includes('secret')))
+  await assert.rejects(() => sandbox.fs.writeFile('/input/new.txt', Buffer.from('forbidden')), { code: 'EACCES' })
+  await assert.rejects(() => sandbox.fs.mkdir('/input/new-dir'), { code: 'EACCES' })
+  await assert.rejects(() => sandbox.fs.stat('/input/../root-secret.txt'), { code: 'ENOENT' })
+  assert.ok((await sandbox.fs.readdir('/input')).every((entry) => !entry.name.includes('secret')))
 
-  const redirect = await sandbox.exec('echo forbidden > /new.txt')
+  const redirect = await sandbox.exec('echo forbidden > /input/new.txt')
   assert.notEqual(redirect.exitCode, 0)
   assert.match(redirect.stderr, /Permission denied/)
 })
 
-test('s3Vfs makes real reads from an explicitly empty bucket-root prefix', { skip: !live }, async () => {
-  const sandbox = new Sandbox({ s3Vfs: liveOptions('') })
-  const fullKey = `/${requiredEnv('TINYSANDBOX_S3_TEST_PREFIX')}/alpha.txt`
+test('S3 mount makes real reads from an explicitly empty bucket-root prefix', { skip: !live }, async () => {
+  const sandbox = sandboxWithS3(liveOptions(''))
+  const fullKey = `/input/${requiredEnv('TINYSANDBOX_S3_TEST_PREFIX')}/alpha.txt`
   assert.equal(String(await sandbox.fs.readFile(fullKey)), 'alpha\n')
 })
 
-test('s3Vfs treats a missing configured prefix as an empty virtual root', { skip: !live }, async () => {
+test('S3 mount treats a missing configured prefix as an empty virtual root', { skip: !live }, async () => {
   const missingPrefix = `${requiredEnv('TINYSANDBOX_S3_TEST_PREFIX')}-missing`
-  const sandbox = new Sandbox({ s3Vfs: liveOptions(missingPrefix) })
-  assert.deepEqual(await sandbox.fs.stat('/'), {
+  const sandbox = sandboxWithS3(liveOptions(missingPrefix))
+  assert.deepEqual(await sandbox.fs.stat('/input'), {
     fileType: 'directory',
     len: 0,
     isFile: false,
     isDir: true
   })
-  assert.deepEqual(await sandbox.fs.readdir('/'), [])
-  await assert.rejects(() => sandbox.fs.stat('/missing.txt'), { code: 'ENOENT' })
+  assert.deepEqual(await sandbox.fs.readdir('/input'), [])
+  await assert.rejects(() => sandbox.fs.stat('/input/missing.txt'), { code: 'ENOENT' })
 })
 
-test('s3Vfs default AWS region and credential chains can read the live fixture', { skip: !live }, async () => {
-  const sandbox = new Sandbox({
-    s3Vfs: {
-      bucket: requiredEnv('TINYSANDBOX_S3_TEST_BUCKET'),
-      prefix: requiredEnv('TINYSANDBOX_S3_TEST_PREFIX'),
-      endpointUrl: requireLoopbackEndpoint(),
-      forcePathStyle: true
-    }
+test('S3 mount default AWS region and credential chains can read the live fixture', { skip: !live }, async () => {
+  const sandbox = sandboxWithS3({
+    bucket: requiredEnv('TINYSANDBOX_S3_TEST_BUCKET'),
+    prefix: requiredEnv('TINYSANDBOX_S3_TEST_PREFIX'),
+    endpointUrl: requireLoopbackEndpoint(),
+    forcePathStyle: true
   })
-  assert.equal(String(await sandbox.fs.readFile('/alpha.txt')), 'alpha\n')
+  assert.equal(String(await sandbox.fs.readFile('/input/alpha.txt')), 'alpha\n')
 })

--- a/tinysandbox-node/__test__/sandbox.test.mjs
+++ b/tinysandbox-node/__test__/sandbox.test.mjs
@@ -36,6 +36,12 @@ test('wall-clock limit validation rejects invalid numbers without aborting Node'
   assert.throws(() => new Sandbox({ limits: { wallTimeMs: -5 } }), /wallTimeMs/)
 })
 
+test('removed single-root VFS selectors fail loudly', () => {
+  for (const option of ['vfs', 'localVfs', 's3Vfs']) {
+    assert.throws(() => new Sandbox({ [option]: {} }), /replaced by the mounts option/)
+  }
+})
+
 test('numeric validation rejects unsafe byte counts and VFS lengths', async () => {
   // Oversized lengths must fail before native code allocates a Vec for the read.
   const unsafeInteger = Number.MAX_SAFE_INTEGER + 1
@@ -43,8 +49,8 @@ test('numeric validation rejects unsafe byte counts and VFS lengths', async () =
   assert.throws(() => new Sandbox({ limits: { jqInputBytes: unsafeInteger } }), /EINVAL/)
 
   const sandbox = new Sandbox()
-  await sandbox.fs.writeFile('/x', Buffer.from('abc'))
-  const handle = await sandbox.fs.open('/x', { read: true })
+  await sandbox.fs.writeFile('/workspace/x', Buffer.from('abc'))
+  const handle = await sandbox.fs.open('/workspace/x', { read: true })
   try {
     await assert.rejects(
       () => sandbox.fs.readAt(handle, 0, unsafeInteger),
@@ -90,8 +96,8 @@ test('jq builtin and jqInputBytes limit are available through Node options', asy
   }
 
   const deepJson = `${'['.repeat(1100)}0${']'.repeat(1100)}`
-  await sandbox.fs.writeFile('/deep.json', Buffer.from(deepJson))
-  const deepInput = await sandbox.exec("jq -c '.' /deep.json")
+  await sandbox.fs.writeFile('/workspace/deep.json', Buffer.from(deepJson))
+  const deepInput = await sandbox.exec("jq -c '.' /workspace/deep.json")
   assert.equal(deepInput.exitCode, 2)
   assert.match(deepInput.stderr, /JSON nesting exceeds/)
 })
@@ -100,22 +106,22 @@ test('direct VFS calls read, write, stat, readdir, and unlink', async () => {
   // Host-side VFS calls should work without shelling through exec.
   const sandbox = new Sandbox()
   assert.equal(sandbox.fs, sandbox.fs)
-  await sandbox.fs.mkdir('/work')
-  await sandbox.fs.writeFile('/work/a.txt', Buffer.from('alpha'))
-  assert.equal(String(await sandbox.fs.readFile('/work/a.txt')), 'alpha')
-  assert.deepEqual(await sandbox.fs.stat('/work/a.txt'), {
+  await sandbox.fs.mkdir('/workspace/work')
+  await sandbox.fs.writeFile('/workspace/work/a.txt', Buffer.from('alpha'))
+  assert.equal(String(await sandbox.fs.readFile('/workspace/work/a.txt')), 'alpha')
+  assert.deepEqual(await sandbox.fs.stat('/workspace/work/a.txt'), {
     fileType: 'file',
     len: 5,
     isFile: true,
     isDir: false
   })
-  assert.deepEqual((await sandbox.fs.readdir('/work')).map((entry) => entry.name), ['a.txt'])
-  await sandbox.fs.unlink('/work/a.txt')
+  assert.deepEqual((await sandbox.fs.readdir('/workspace/work')).map((entry) => entry.name), ['a.txt'])
+  await sandbox.fs.unlink('/workspace/work/a.txt')
   await assert.rejects(
-    () => sandbox.fs.stat('/work/a.txt'),
+    () => sandbox.fs.stat('/workspace/work/a.txt'),
     (err) => {
       assert.equal(err.code, 'ENOENT')
-      assert.match(err.message, /\/work\/a\.txt/)
+      assert.match(err.message, /\/workspace\/work\/a\.txt/)
       return true
     }
   )
@@ -125,10 +131,10 @@ test('cached direct VFS calls use the current persistent session cwd', async () 
   // The JS facade stays stable while native path resolution follows later cd calls.
   const sandbox = new Sandbox({ persistSession: true })
   const fs = sandbox.fs
-  await fs.mkdir('/a')
-  await sandbox.exec('cd /a')
+  await fs.mkdir('/workspace/a')
+  await sandbox.exec('cd /workspace/a')
   await fs.writeFile('y.txt', Buffer.from('cwd-aware'))
-  assert.equal(String(await fs.readFile('/a/y.txt')), 'cwd-aware')
+  assert.equal(String(await fs.readFile('/workspace/a/y.txt')), 'cwd-aware')
   await assert.rejects(() => fs.stat('/y.txt'), { code: 'ENOENT' })
 })
 
@@ -154,17 +160,37 @@ test('JS VFS conformance runner accepts callback implementations', async () => {
 
 test('Sandbox can execute against a JS VFS adapter', async () => {
   // Exercises the Rust sync Vfs trait backed by async JS callbacks through TSFN.
-  const sandbox = new Sandbox({ vfs: createMemoryVfs() })
-  await sandbox.fs.mkdir('/app')
-  await sandbox.fs.writeFile('/app/input.txt', Buffer.from('one\ntwo\n'))
-  const result = await sandbox.exec('cat /app/input.txt | wc -l')
+  const sandbox = new Sandbox({ mounts: { workspace: { type: 'custom', vfs: createMemoryVfs() } } })
+  await sandbox.fs.mkdir('/workspace/app')
+  await sandbox.fs.writeFile('/workspace/app/input.txt', Buffer.from('one\ntwo\n'))
+  const result = await sandbox.exec('cat /workspace/app/input.txt | wc -l')
   assert.equal(result.stdout, '      2\n')
+})
+
+test('static mounts are listed at root and route operations independently', async () => {
+  const sandbox = new Sandbox({
+    mounts: {
+      input: { type: 'custom', vfs: createMemoryVfs() },
+      output: { type: 'custom', vfs: createMemoryVfs() }
+    },
+    cwd: '/input'
+  })
+
+  assert.deepEqual((await sandbox.fs.readdir('/')).map((entry) => entry.name), ['bin', 'input', 'output'])
+  await sandbox.fs.writeFile('/input/source.txt', Buffer.from('mounted'))
+  const copied = await sandbox.exec('cp /input/source.txt /output/copied.txt')
+  assert.equal(copied.exitCode, 0, copied.stderr)
+  assert.equal(String(await sandbox.fs.readFile('/output/copied.txt')), 'mounted')
+  await assert.rejects(
+    () => sandbox.fs.rename('/input/source.txt', '/output/moved.txt'),
+    { code: 'EXDEV' }
+  )
 })
 
 test('Sandbox stats can call a JS VFS stats callback without deadlocking', async () => {
   // stats() is async because JS VFS callbacks need the main thread to keep pumping promises.
-  const sandbox = new Sandbox({ vfs: createMemoryVfs() })
-  await sandbox.fs.writeFile('/stats.txt', Buffer.from('abc'))
+  const sandbox = new Sandbox({ mounts: { workspace: { type: 'custom', vfs: createMemoryVfs() } } })
+  await sandbox.fs.writeFile('/workspace/stats.txt', Buffer.from('abc'))
   const stats = await Promise.race([
     sandbox.stats(),
     new Promise((_, reject) => setTimeout(() => reject(new Error('deadlocked')), 1000))
@@ -175,9 +201,9 @@ test('Sandbox stats can call a JS VFS stats callback without deadlocking', async
 test('Node e2e pipeline can cat into the sandboxed js command', async () => {
   // Direct host writes and the built-in Wasmtime QuickJS command share the same VFS.
   const sandbox = new Sandbox()
-  await sandbox.fs.writeFile('/x', Buffer.from('abc'))
-  await sandbox.fs.writeFile('/t.js', Buffer.from('const fs = require("fs")\nconsole.log(fs.readFileSync("/x", "utf8").toUpperCase())\n'))
-  const result = await sandbox.exec('cat /x | js /t.js')
+  await sandbox.fs.writeFile('/workspace/x', Buffer.from('abc'))
+  await sandbox.fs.writeFile('/workspace/t.js', Buffer.from('const fs = require("fs")\nconsole.log(fs.readFileSync("/workspace/x", "utf8").toUpperCase())\n'))
+  const result = await sandbox.exec('cat /workspace/x | js /workspace/t.js')
   assert.equal(result.exitCode, 0)
   assert.equal(result.stdout, 'ABC\n')
 })
@@ -323,8 +349,8 @@ test('direct VFS calls proceed while exec is in flight', async () => {
     }
   })
   const running = sandbox.exec('wait')
-  await sandbox.fs.writeFile('/during.txt', Buffer.from('ok'))
-  assert.equal(String(await sandbox.fs.readFile('/during.txt')), 'ok')
+  await sandbox.fs.writeFile('/workspace/during.txt', Buffer.from('ok'))
+  assert.equal(String(await sandbox.fs.readFile('/workspace/during.txt')), 'ok')
   assert.equal((await running).stdout, 'done\n')
 })
 
@@ -336,10 +362,10 @@ test('JS VFS callbacks do not deadlock on the same event loop', async () => {
     await Promise.resolve()
     return originalReadAt(request)
   }
-  const sandbox = new Sandbox({ vfs })
-  await sandbox.fs.writeFile('/x', Buffer.from('deadlock-free'))
+  const sandbox = new Sandbox({ mounts: { workspace: { type: 'custom', vfs } } })
+  await sandbox.fs.writeFile('/workspace/x', Buffer.from('deadlock-free'))
   const result = await Promise.race([
-    sandbox.exec('cat /x'),
+    sandbox.exec('cat /workspace/x'),
     new Promise((_, reject) => setTimeout(() => reject(new Error('deadlocked')), 1000))
   ])
   assert.equal(result.stdout, 'deadlock-free')
@@ -350,9 +376,9 @@ test('unknown JS VFS error text collapses to EINVAL instead of substring matchin
   vfs.stat = async () => {
     throw new Error('file ENOENT-ish not really')
   }
-  const sandbox = new Sandbox({ vfs })
+  const sandbox = new Sandbox({ mounts: { workspace: { type: 'custom', vfs } } })
   await assert.rejects(
-    () => sandbox.fs.stat('/x'),
+    () => sandbox.fs.stat('/workspace/x'),
     (err) => {
       assert.equal(err.code, 'EINVAL')
       return true
@@ -367,18 +393,18 @@ test('JS VFS request data is delivered as a Buffer', async () => {
     assert.equal(Buffer.isBuffer(request.data), true)
     return originalWriteAt(request)
   }
-  const sandbox = new Sandbox({ vfs })
-  await sandbox.fs.writeFile('/buffer.txt', Buffer.from('buffered'))
-  assert.equal(String(await sandbox.fs.readFile('/buffer.txt')), 'buffered')
+  const sandbox = new Sandbox({ mounts: { workspace: { type: 'custom', vfs } } })
+  await sandbox.fs.writeFile('/workspace/buffer.txt', Buffer.from('buffered'))
+  assert.equal(String(await sandbox.fs.readFile('/workspace/buffer.txt')), 'buffered')
 })
 
 test('JS VFS adapters do not keep child processes alive', async () => {
   const script = `
     import { Sandbox } from './index.js'
     import { createMemoryVfs } from './__test__/helpers.mjs'
-    const sandbox = new Sandbox({ vfs: createMemoryVfs() })
-    await sandbox.fs.writeFile('/x', Buffer.from('ok'))
-    const result = await sandbox.exec('cat /x')
+    const sandbox = new Sandbox({ mounts: { workspace: { type: 'custom', vfs: createMemoryVfs() } } })
+    await sandbox.fs.writeFile('/workspace/x', Buffer.from('ok'))
+    const result = await sandbox.exec('cat /workspace/x')
     if (result.stdout !== 'ok') process.exit(2)
   `
 

--- a/tinysandbox-node/examples/js_scripts.ts
+++ b/tinysandbox-node/examples/js_scripts.ts
@@ -6,7 +6,7 @@ async function main() {
     limits: { wasmMemoryBytes: 32 * 1024 * 1024 }
   })
 
-  await sandbox.exec(`mkdir -p /app && cd /app && echo 'exports.stats = (text) => {
+  await sandbox.exec(`mkdir -p /workspace/app && cd /workspace/app && echo 'exports.stats = (text) => {
   const words = text.split(/\\s+/).filter(Boolean)
   return { words: words.length, unique: new Set(words).size }
 }' > helper.js`)
@@ -16,14 +16,14 @@ const { stats } = require("./helper.js")
 const text = fs.readFileSync(process.argv[2], "utf8")
 const result = stats(text)
 console.log(JSON.stringify(result))
-fs.writeFileSync("/app/stats.json", JSON.stringify(result))' > main.js`)
+fs.writeFileSync("/workspace/app/stats.json", JSON.stringify(result))' > main.js`)
 
   await sandbox.exec("echo 'the quick brown fox jumps over the lazy dog' > input.txt")
 
   const result = await sandbox.exec('js main.js input.txt')
   process.stdout.write(`stdout: ${result.stdout}`)
 
-  const bytes = await sandbox.exec('cat /app/stats.json | wc -c')
+  const bytes = await sandbox.exec('cat /workspace/app/stats.json | wc -c')
   process.stdout.write(`stats.json bytes: ${bytes.stdout}`)
 
   const expression = await sandbox.exec("js -e 'console.log(6 * 7)'")

--- a/tinysandbox-node/examples/js_syscalls.ts
+++ b/tinysandbox-node/examples/js_syscalls.ts
@@ -54,9 +54,9 @@ try {
   console.log(\`\${response.status}:\${await response.text()}\`)
 })()
 `
-  await sandbox.fs.writeFile('/main.js', Buffer.from(script))
+  await sandbox.fs.writeFile('/workspace/main.js', Buffer.from(script))
 
-  const result = await sandbox.exec('js /main.js')
+  const result = await sandbox.exec('js /workspace/main.js')
   process.stdout.write(result.stdout)
   console.assert(result.exitCode === 0, result.stderr)
   console.assert(result.stdout === 'answer=42\nE_KEY:key is required\n200:echo:ping\n')

--- a/tinysandbox-node/examples/js_vfs.ts
+++ b/tinysandbox-node/examples/js_vfs.ts
@@ -5,8 +5,9 @@ async function main() {
   const conformance = await runConformance((quota) => createMemoryVfs(quota))
   console.log('conformance:', conformance)
 
-  const sandbox = new Sandbox({ vfs: createMemoryVfs() })
-  await sandbox.fs.mkdir('/workspace')
+  const sandbox = new Sandbox({
+    mounts: { workspace: { type: 'custom', vfs: createMemoryVfs() } }
+  })
   await sandbox.fs.writeFile('/workspace/input.txt', Buffer.from('one\ntwo\nthree\n'))
 
   const result = await sandbox.exec('cat /workspace/input.txt | wc -l')

--- a/tinysandbox-node/index.d.ts
+++ b/tinysandbox-node/index.d.ts
@@ -37,35 +37,44 @@ export interface SandboxOptions {
   syscalls?: Record<string, JsSyscall>
   jsPrelude?: string
   fetch?: JsFetch
-  /** Custom VFS implemented in JavaScript. Mutually exclusive with localVfs and s3Vfs. */
-  vfs?: JsVfs
-  /** Persist the sandbox filesystem under a host directory. Mutually exclusive with vfs and s3Vfs. */
-  localVfs?: LocalVfsOptions
-  /** Read-only S3 bucket/prefix filesystem. Mutually exclusive with vfs and localVfs. */
-  s3Vfs?: S3VfsOptions
+  /** Static top-level filesystem mounts. Replaces the default in-memory workspace when present. */
+  mounts?: Record<string, MountOptions>
+}
+
+export type MountOptions =
+  | ({ type: 'memory' } & MemoryVfsOptions)
+  | ({ type: 'local' } & LocalVfsOptions)
+  | ({ type: 's3' } & S3VfsOptions)
+  | { type: 'custom', vfs: JsVfs }
+
+export interface MemoryVfsOptions {
+  /** Storage limits. Unset fields are unlimited. */
+  quota?: VfsQuotaOptions
+}
+
+export interface VfsQuotaOptions {
+  maxBytes?: number
+  maxFiles?: number
+  maxFileSize?: number
 }
 
 /**
  * Backs the sandbox filesystem with a directory on the host (Unix only).
  *
- * Sandbox paths resolve strictly beneath the root: `..` is clamped at the
- * sandbox root and symlinks are never followed. The directory must exist and
+ * Paths within the mount resolve strictly beneath the root: `..` is clamped at
+ * the virtual sandbox root and symlinks are never followed. The directory must exist and
  * should be dedicated to the sandbox; existing regular files and directories
  * are visible inside and count toward the quota.
  */
 export interface LocalVfsOptions {
-  /** Existing host directory that becomes the sandbox root `/`. */
+  /** Existing host directory that becomes this mount's root. */
   root: string
   /** Storage limits. Unset fields are unlimited. */
-  quota?: {
-    maxBytes?: number
-    maxFiles?: number
-    maxFileSize?: number
-  }
+  quota?: VfsQuotaOptions
 }
 
 /**
- * Exposes one S3 bucket/key prefix as the read-only sandbox root `/`.
+ * Exposes one S3 bucket/key prefix as a read-only mount root.
  *
  * Region and credentials use the AWS SDK default provider chains when they
  * are omitted. Endpoint and path-style overrides support compatible services.
@@ -73,7 +82,7 @@ export interface LocalVfsOptions {
 export interface S3VfsOptions {
   /** Bucket containing the exposed objects. */
   bucket: string
-  /** Key prefix exposed as `/`; leading/trailing slashes are normalized. */
+  /** Key prefix exposed at the mount root. Leading/trailing slashes are normalized. */
   prefix?: string
   /** AWS region override. */
   region?: string
@@ -194,6 +203,7 @@ export interface VfsCallbackError {
 export type VfsErrno =
   | 'EBADF'
   | 'EBUSY'
+  | 'EXDEV'
   | 'EACCES'
   | 'EEXIST'
   | 'EIO'

--- a/tinysandbox-node/index.js
+++ b/tinysandbox-node/index.js
@@ -25,9 +25,18 @@ function normalizeOptions(options) {
   else delete normalized.syscalls
   if (options.fetch) normalized.fetch = wrapFetch(options.fetch)
   else delete normalized.fetch
-  if (options.vfs) normalized.vfs = wrapVfs(options.vfs)
-  else delete normalized.vfs
+  if (options.mounts) normalized.mounts = wrapMounts(options.mounts)
+  else delete normalized.mounts
   return normalized
+}
+
+function wrapMounts(mounts) {
+  return Object.fromEntries(
+    Object.entries(mounts).map(([name, mount]) => [
+      name,
+      mount?.type === 'custom' ? { ...mount, vfs: wrapVfs(mount.vfs) } : mount
+    ])
+  )
 }
 
 function wrapCommands(commands) {
@@ -254,6 +263,7 @@ const vfsOperations = [
 const errnos = [
   'EBADF',
   'EBUSY',
+  'EXDEV',
   'EACCES',
   'EEXIST',
   'EIO',

--- a/tinysandbox-node/native.d.ts
+++ b/tinysandbox-node/native.d.ts
@@ -13,20 +13,15 @@ export declare class NativeSandbox {
   get fs(): SandboxFs
   stats(): Promise<SandboxStats>
   /**
-   * Rescans the localVfs root directory and replaces quota usage with the
-   * result. Call this after the host mutates the directory outside the
-   * sandbox. Rejects when the sandbox was not built with the localVfs
-   * option.
+   * Rescans a local mount's host directory and replaces its quota usage.
+   * Call this after the host mutates the directory outside the sandbox.
    */
-  refreshLocalVfs(): Promise<VfsStatsJs>
+  refreshLocalVfs(mount: string): Promise<VfsStatsJs>
   /**
-   * Replaces localVfs quota usage with externally computed numbers, for
-   * hosts that track usage out of band. Later file operations apply their
-   * deltas on top of the pushed baseline and quota enforcement blocks
-   * growth against it. Throws when the sandbox was not built with the
-   * localVfs option.
+   * Replaces a local mount's quota usage with externally computed numbers.
+   * Later file operations apply their deltas on top of the pushed baseline.
    */
-  setLocalVfsUsage(usage: VfsStatsJs): void
+  setLocalVfsUsage(mount: string, usage: VfsStatsJs): void
 }
 export type Sandbox = NativeSandbox
 

--- a/tinysandbox-node/package-lock.json
+++ b/tinysandbox-node/package-lock.json
@@ -2054,16 +2054,74 @@
       }
     },
     "node_modules/@tinysandbox/tinysandbox-darwin-arm64": {
-      "optional": true
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@tinysandbox/tinysandbox-darwin-arm64/-/tinysandbox-darwin-arm64-0.4.7.tgz",
+      "integrity": "sha512-fGZeCvc0ae+VNBmsrdVhCOQ9gaV3waJR2xlWoXi4+IpZM/R/YRg6JOERrw/D4HRMa4kEUWIIwVbqiaEG53r/7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@tinysandbox/tinysandbox-darwin-x64": {
-      "optional": true
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@tinysandbox/tinysandbox-darwin-x64/-/tinysandbox-darwin-x64-0.4.7.tgz",
+      "integrity": "sha512-G7ElOFbiDZ38mdvwoeUuXSijp5/d4tVQPTEoMNQB92H2G1Oue9TO/uIrj6FL0dief9+8Rq/ELh7jS5jEZDHoAg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@tinysandbox/tinysandbox-linux-arm64-gnu": {
-      "optional": true
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@tinysandbox/tinysandbox-linux-arm64-gnu/-/tinysandbox-linux-arm64-gnu-0.4.7.tgz",
+      "integrity": "sha512-t4HW1RrHG2HxevMjzjHAhy+xYl4zX3cdkBN37ah4K/oqHTzrH5G3k9qP/lE5NeFf5Lo6LHe6blkvop8wfXclqQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@tinysandbox/tinysandbox-linux-x64-gnu": {
-      "optional": true
+      "version": "0.4.7",
+      "resolved": "https://registry.npmjs.org/@tinysandbox/tinysandbox-linux-x64-gnu/-/tinysandbox-linux-x64-gnu-0.4.7.tgz",
+      "integrity": "sha512-B0JQMR/m9sirH4d1wmObqIctCP8SxoqqAMS1b5J4BUrWTCcOf4qPIUxHAs1tqPOKdpSP+Q0s0muUXmmILD/6zg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",

--- a/tinysandbox-node/src/lib.rs
+++ b/tinysandbox-node/src/lib.rs
@@ -17,8 +17,8 @@ use tinysandbox::sandbox::{
     Sandbox as CoreSandbox, SyscallError,
 };
 use tinysandbox::vfs::{
-    DirEntry, Errno, FileHandle, FileType, Metadata, OpenMode, Vfs, VfsError, VfsQuota, VfsResult,
-    VfsStats,
+    DirEntry, Errno, FileHandle, FileType, InMemoryVfs, Metadata, OpenMode, Vfs, VfsError,
+    VfsQuota, VfsResult, VfsStats,
 };
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -70,7 +70,7 @@ pub struct Sandbox {
     // Concrete handle kept alongside the type-erased one in the sandbox so
     // refreshLocalVfs/setLocalVfsUsage can reach the LocalVfs-only API.
     #[cfg(unix)]
-    local_vfs: Option<Arc<tinysandbox::vfs::LocalVfs>>,
+    local_vfs: HashMap<String, Arc<tinysandbox::vfs::LocalVfs>>,
 }
 
 #[napi]
@@ -79,10 +79,17 @@ impl Sandbox {
     pub fn new(options: Option<Object<'_>>) -> Result<Self> {
         let mut builder = CoreSandbox::builder();
         #[cfg(unix)]
-        let mut local_vfs = None;
+        let mut local_vfs = HashMap::new();
 
         if let Some(options) = options {
-            validate_builtin_vfs_selection(&options)?;
+            for removed in ["vfs", "localVfs", "s3Vfs"] {
+                if has_non_nullish_named_property(&options, removed)? {
+                    return Err(Error::new(
+                        Status::InvalidArg,
+                        format!("Sandbox option '{removed}' was replaced by the mounts option"),
+                    ));
+                }
+            }
             if let Some(limits) = get_optional_object(&options, "limits")? {
                 builder = builder.limits(parse_limits(limits)?);
             }
@@ -134,24 +141,51 @@ impl Sandbox {
                     async move { call_js_fetch(callback, request).await }
                 });
             }
-            if let Some(vfs) = get_optional_object(&options, "vfs")? {
-                builder = builder.vfs_arc(Arc::new(JsVfs::new(vfs)?));
-            }
-            #[cfg(unix)]
-            if let Some(local_vfs_options) = get_optional_object(&options, "localVfs")? {
-                let vfs = build_local_vfs(&local_vfs_options)?;
-                local_vfs = Some(Arc::clone(&vfs));
-                builder = builder.vfs_arc(vfs);
-            }
-            #[cfg(not(unix))]
-            if has_non_nullish_named_property(&options, "localVfs")? {
-                return Err(Error::new(
-                    Status::InvalidArg,
-                    "localVfs is only supported on Unix hosts".to_owned(),
-                ));
-            }
-            if let Some(s3_vfs_options) = get_optional_object(&options, "s3Vfs")? {
-                builder = builder.vfs_arc(build_s3_vfs(&s3_vfs_options)?);
+            if let Some(mounts) = get_optional_object(&options, "mounts")? {
+                builder = builder.clear_mounts();
+                for name in Object::keys(&mounts)? {
+                    tinysandbox::vfs::mount::validate_mount_name(&name).map_err(|_| {
+                        Error::new(
+                            Status::InvalidArg,
+                            format!(
+                                "mount name '{name}' must be a non-reserved single path component"
+                            ),
+                        )
+                    })?;
+                    let mount: Object<'_> = mounts.get_named_property(&name)?;
+                    let kind: String = mount.get_named_property("type")?;
+                    let vfs: Arc<dyn Vfs> = match kind.as_str() {
+                        "memory" => Arc::new(InMemoryVfs::new(parse_vfs_quota(
+                            &mount,
+                            &format!("memory mount '{name}'"),
+                        )?)),
+                        "custom" => {
+                            let custom: Object<'_> = mount.get_named_property("vfs")?;
+                            Arc::new(JsVfs::new(custom)?)
+                        }
+                        #[cfg(unix)]
+                        "local" => {
+                            let local = build_local_vfs(&mount, &name)?;
+                            local_vfs.insert(name.clone(), Arc::clone(&local));
+                            local
+                        }
+                        #[cfg(not(unix))]
+                        "local" => {
+                            return Err(Error::new(
+                                Status::InvalidArg,
+                                format!("local mount '{name}' is only supported on Unix hosts"),
+                            ));
+                        }
+                        "s3" => build_s3_vfs(&mount)?,
+                        _ => {
+                            return Err(Error::new(
+                                Status::InvalidArg,
+                                format!("mount '{name}' type must be memory, local, s3, or custom"),
+                            ));
+                        }
+                    };
+                    builder = builder.mount_arc(name, vfs);
+                }
             }
             if let Some(commands) = get_optional_object(&options, "commands")? {
                 for name in Object::keys(&commands)? {
@@ -205,15 +239,17 @@ impl Sandbox {
         .map_err(|err| Error::new(Status::GenericFailure, err.to_string()))
     }
 
-    /// Rescans the localVfs root directory and replaces quota usage with the
-    /// result. Call this after the host mutates the directory outside the
-    /// sandbox. Rejects when the sandbox was not built with the localVfs
-    /// option.
+    /// Rescans a local mount's host directory and replaces its quota usage.
+    /// Call this after the host mutates the directory outside the sandbox.
     #[napi]
-    pub async fn refresh_local_vfs(&self) -> Result<VfsStatsJs> {
+    pub async fn refresh_local_vfs(&self, mount: String) -> Result<VfsStatsJs> {
         #[cfg(unix)]
         {
-            let vfs = self.local_vfs.clone().ok_or_else(local_vfs_missing)?;
+            let vfs = self
+                .local_vfs
+                .get(&mount)
+                .cloned()
+                .ok_or_else(|| local_vfs_missing(&mount))?;
             tokio::task::spawn_blocking(move || {
                 vfs.refresh()
                     .map(VfsStatsJs::from)
@@ -224,24 +260,26 @@ impl Sandbox {
         }
         #[cfg(not(unix))]
         {
-            Err(local_vfs_missing())
+            Err(local_vfs_missing(&mount))
         }
     }
 
-    /// Replaces localVfs quota usage with externally computed numbers, for
-    /// hosts that track usage out of band. Later file operations apply their
-    /// deltas on top of the pushed baseline and quota enforcement blocks
-    /// growth against it. Throws when the sandbox was not built with the
-    /// localVfs option.
+    /// Replaces a local mount's quota usage with externally computed numbers.
+    /// Later file operations apply their deltas on top of the pushed baseline.
     #[napi]
-    pub fn set_local_vfs_usage(&self, usage: VfsStatsJs) -> Result<()> {
+    pub fn set_local_vfs_usage(&self, mount: String, usage: VfsStatsJs) -> Result<()> {
         #[cfg(unix)]
         {
-            let vfs = self.local_vfs.as_ref().ok_or_else(local_vfs_missing)?;
+            let vfs = self
+                .local_vfs
+                .get(&mount)
+                .ok_or_else(|| local_vfs_missing(&mount))?;
             let invalid = |field: &str| {
                 Error::new(
                     Status::InvalidArg,
-                    format!("localVfs usage {field} must be a non-negative safe integer"),
+                    format!(
+                        "local mount '{mount}' usage {field} must be a non-negative safe integer"
+                    ),
                 )
             };
             vfs.set_usage(VfsStats {
@@ -253,15 +291,15 @@ impl Sandbox {
         #[cfg(not(unix))]
         {
             let _ = usage;
-            Err(local_vfs_missing())
+            Err(local_vfs_missing(&mount))
         }
     }
 }
 
-fn local_vfs_missing() -> Error {
+fn local_vfs_missing(mount: &str) -> Error {
     Error::new(
         Status::GenericFailure,
-        "sandbox was not configured with the localVfs option".to_owned(),
+        format!("sandbox mount '{mount}' is not a local filesystem"),
     )
 }
 
@@ -1185,23 +1223,6 @@ fn parse_limits(limits: Object<'_>) -> Result<Limits> {
     Ok(parsed)
 }
 
-fn validate_builtin_vfs_selection(options: &Object<'_>) -> Result<()> {
-    let mut configured = Vec::new();
-    for name in ["vfs", "localVfs", "s3Vfs"] {
-        if has_non_nullish_named_property(options, name)? {
-            configured.push(name);
-        }
-    }
-    if configured.len() > 1 {
-        return Err(Error::new(
-            Status::InvalidArg,
-            "Sandbox constructor accepts either vfs or localVfs or s3Vfs, not more than one"
-                .to_owned(),
-        ));
-    }
-    Ok(())
-}
-
 struct S3ClientOptions {
     region: Option<String>,
     endpoint_url: Option<String>,
@@ -1216,10 +1237,10 @@ struct S3Credentials {
 }
 
 fn build_s3_vfs(options: &Object<'_>) -> Result<Arc<tinysandbox::vfs::S3Vfs>> {
-    let bucket = required_nonempty_string(options, "bucket", "s3Vfs")?;
+    let bucket = required_nonempty_string(options, "bucket", "S3 mount")?;
     let prefix = get_optional::<String>(options, "prefix")?;
-    let region = optional_nonempty_string(options, "region", "s3Vfs")?;
-    let endpoint_url = optional_nonempty_string(options, "endpointUrl", "s3Vfs")?;
+    let region = optional_nonempty_string(options, "region", "S3 mount")?;
+    let endpoint_url = optional_nonempty_string(options, "endpointUrl", "S3 mount")?;
     let force_path_style = get_optional::<bool>(options, "forcePathStyle")?;
     let credentials = get_optional_object(options, "credentials")?
         .map(|credentials| parse_s3_credentials(&credentials))
@@ -1234,7 +1255,7 @@ fn build_s3_vfs(options: &Object<'_>) -> Result<Arc<tinysandbox::vfs::S3Vfs>> {
     let vfs = tinysandbox::vfs::S3Vfs::new(client, bucket, prefix.as_deref()).map_err(|err| {
         Error::new(
             Status::InvalidArg,
-            format!("invalid s3Vfs bucket or prefix: {err}"),
+            format!("invalid S3 mount bucket or prefix: {err}"),
         )
     })?;
     Ok(Arc::new(vfs))
@@ -1242,13 +1263,21 @@ fn build_s3_vfs(options: &Object<'_>) -> Result<Arc<tinysandbox::vfs::S3Vfs>> {
 
 fn parse_s3_credentials(credentials: &Object<'_>) -> Result<S3Credentials> {
     Ok(S3Credentials {
-        access_key_id: required_nonempty_string(credentials, "accessKeyId", "s3Vfs credentials")?,
+        access_key_id: required_nonempty_string(
+            credentials,
+            "accessKeyId",
+            "S3 mount credentials",
+        )?,
         secret_access_key: required_nonempty_string(
             credentials,
             "secretAccessKey",
-            "s3Vfs credentials",
+            "S3 mount credentials",
         )?,
-        session_token: optional_nonempty_string(credentials, "sessionToken", "s3Vfs credentials")?,
+        session_token: optional_nonempty_string(
+            credentials,
+            "sessionToken",
+            "S3 mount credentials",
+        )?,
     })
 }
 
@@ -1302,7 +1331,7 @@ fn build_s3_client(options: S3ClientOptions) -> Result<aws_sdk_s3::Client> {
                         credentials.secret_access_key,
                         credentials.session_token,
                         None,
-                        "tinysandbox-node-s3Vfs",
+                        "tinysandbox-node-s3-mount",
                     ));
                 }
                 let shared_config = loader.load().await;
@@ -1319,7 +1348,7 @@ fn build_s3_client(options: S3ClientOptions) -> Result<aws_sdk_s3::Client> {
         .map_err(|err| {
             Error::new(
                 Status::GenericFailure,
-                format!("could not start s3Vfs configuration: {err}"),
+                format!("could not start S3 mount configuration: {err}"),
             )
         })?;
 
@@ -1327,42 +1356,50 @@ fn build_s3_client(options: S3ClientOptions) -> Result<aws_sdk_s3::Client> {
         Ok(Ok(client)) => Ok(client),
         Ok(Err(message)) => Err(Error::new(
             Status::GenericFailure,
-            format!("could not configure s3Vfs: {message}"),
+            format!("could not configure S3 mount: {message}"),
         )),
         Err(_) => Err(Error::new(
             Status::GenericFailure,
-            "could not configure s3Vfs: configuration worker panicked".to_owned(),
+            "could not configure S3 mount: configuration worker panicked".to_owned(),
         )),
     }
 }
 
 #[cfg(unix)]
-fn build_local_vfs(options: &Object<'_>) -> Result<Arc<tinysandbox::vfs::LocalVfs>> {
+fn build_local_vfs(options: &Object<'_>, mount: &str) -> Result<Arc<tinysandbox::vfs::LocalVfs>> {
     let root: String = options.get_named_property("root")?;
-    let mut quota = VfsQuota::unlimited();
-    if let Some(limits) = get_optional_object(options, "quota")? {
-        if let Some(value) = get_optional::<f64>(&limits, "maxBytes")? {
-            quota.max_bytes = quota_value(value, "maxBytes")?;
-        }
-        if let Some(value) = get_optional::<f64>(&limits, "maxFiles")? {
-            quota.max_files = quota_value(value, "maxFiles")?;
-        }
-        if let Some(value) = get_optional::<f64>(&limits, "maxFileSize")? {
-            quota.max_file_size = quota_value(value, "maxFileSize")?;
-        }
-    }
+    let quota = parse_vfs_quota(options, &format!("local mount '{mount}'"))?;
 
-    let vfs = tinysandbox::vfs::LocalVfs::with_quota(&root, quota)
-        .map_err(|err| Error::new(Status::InvalidArg, format!("localVfs root '{root}': {err}")))?;
+    let vfs = tinysandbox::vfs::LocalVfs::with_quota(&root, quota).map_err(|err| {
+        Error::new(
+            Status::InvalidArg,
+            format!("local mount '{mount}' root '{root}': {err}"),
+        )
+    })?;
     Ok(Arc::new(vfs))
 }
 
-#[cfg(unix)]
-fn quota_value(value: f64, name: &str) -> Result<u64> {
+fn parse_vfs_quota(options: &Object<'_>, context: &str) -> Result<VfsQuota> {
+    let mut quota = VfsQuota::unlimited();
+    if let Some(limits) = get_optional_object(options, "quota")? {
+        if let Some(value) = get_optional::<f64>(&limits, "maxBytes")? {
+            quota.max_bytes = quota_value(value, context, "maxBytes")?;
+        }
+        if let Some(value) = get_optional::<f64>(&limits, "maxFiles")? {
+            quota.max_files = quota_value(value, context, "maxFiles")?;
+        }
+        if let Some(value) = get_optional::<f64>(&limits, "maxFileSize")? {
+            quota.max_file_size = quota_value(value, context, "maxFileSize")?;
+        }
+    }
+    Ok(quota)
+}
+
+fn quota_value(value: f64, context: &str, name: &str) -> Result<u64> {
     u64_from_js(value).map_err(|_| {
         Error::new(
             Status::InvalidArg,
-            format!("localVfs quota {name} must be a non-negative safe integer"),
+            format!("{context} quota {name} must be a non-negative safe integer"),
         )
     })
 }
@@ -1466,6 +1503,7 @@ fn errno_from_code(code: Option<&str>) -> Errno {
     match code {
         Some("EBADF") => Errno::EBADF,
         Some("EBUSY") => Errno::EBUSY,
+        Some("EXDEV") => Errno::EXDEV,
         Some("EACCES") => Errno::EACCES,
         Some("EEXIST") => Errno::EEXIST,
         Some("EIO") => Errno::EIO,


### PR DESCRIPTION
## Summary

- Add a read-only virtual root with named top-level mounts and synthesized root listings
- Route paths and file handles to independent memory, local, S3, or custom VFS backends
- Default new sandboxes to an in-memory `/workspace` mount and replace the old single-root configuration APIs
- Return `EXDEV` for cross-mount renames while allowing copies between mounts
- Update Rust and Node APIs, docs, prompts, examples, declarations, and tests

## Validation

- `cargo test --workspace --all-features`
- `npm test` with 44 passing tests and 5 opt-in live S3 tests skipped
- `npm run examples`
- `cargo fmt --all -- --check`
- `git diff --check`