### PR TITLE
Fix release version selection and post-publish lockfile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,18 +52,28 @@ jobs:
       - name: Check release eligibility
         id: eligibility
         run: |
-          message="$(git log -1 --format=%B)"
+          set -euo pipefail
+          head_message="$(git log -1 --format=%B)"
           release=true
           if [ "$GITHUB_EVENT_NAME" != "workflow_dispatch" ]; then
-            if [[ "$message" == *"[skip release]"* || "$message" == chore\(release\):* ]]; then
+            if [[ "$head_message" == *"[skip release]"* || "$head_message" == chore\(release\):* ]]; then
               release=false
             fi
           fi
+          # Eligibility reads only the head commit, but version selection reads
+          # every commit since the last release so a Conventional Commits
+          # breaking marker is not hidden behind a merge commit subject.
+          previous_release="$(git log -1 --format=%H --grep '^chore(release): ' HEAD || true)"
+          if [ -n "$previous_release" ] && [ "$previous_release" != "$(git rev-parse HEAD)" ]; then
+            message="$(git log --format=%B "${previous_release}..HEAD")"
+          else
+            message="$head_message"
+          fi
           echo "release=$release" >> "$GITHUB_OUTPUT"
           {
-            echo "message<<EOF"
+            echo "message<<RELEASE_MESSAGE_EOF"
             echo "$message"
-            echo "EOF"
+            echo "RELEASE_MESSAGE_EOF"
           } >> "$GITHUB_OUTPUT"
 
       - uses: dtolnay/rust-toolchain@stable
@@ -424,3 +434,31 @@ jobs:
           else
             npm publish --access public
           fi
+
+      - name: Refresh lockfile with published native packages
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          set -euo pipefail
+          # `release-version.mjs apply` can only leave placeholder entries for
+          # the native packages, because the version does not exist on npm when
+          # the release commit is built. They resolve now that publishing is
+          # done, and `npm ci` rejects the placeholders until they do.
+          npm install --package-lock-only --no-audit --no-fund --prefix tinysandbox-node
+          if git diff --quiet -- tinysandbox-node/package-lock.json; then
+            echo "lockfile already resolves ${VERSION}"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add tinysandbox-node/package-lock.json
+          git commit -m "chore(release): resolve ${VERSION} lockfile entries [skip release]"
+          for attempt in 1 2 3; do
+            if git push origin HEAD:main; then
+              exit 0
+            fi
+            echo "main advanced before the lockfile refresh could be pushed; rebasing (attempt ${attempt})"
+            git fetch origin main
+            git rebase origin/main
+          done
+          git push origin HEAD:main

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2712,7 +2712,7 @@ dependencies = [
 
 [[package]]
 name = "tinysandbox"
-version = "0.4.9"
+version = "0.4.8"
 dependencies = [
  "aws-sdk-s3",
  "base64",
@@ -2730,7 +2730,7 @@ dependencies = [
 
 [[package]]
 name = "tinysandbox-node"
-version = "0.4.9"
+version = "0.4.8"
 dependencies = [
  "aws-config",
  "aws-sdk-s3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "3"
 
 [package]
 name = "tinysandbox"
-version = "0.4.9"
+version = "0.4.8"
 edition = "2024"
 description = "Ultra-minimal Linux-like sandbox for AI agents: shell, coreutils, VFS, and a Wasmtime-hosted JS runtime in one crate"
 license = "MIT OR Apache-2.0"

--- a/scripts/release-version.mjs
+++ b/scripts/release-version.mjs
@@ -28,7 +28,8 @@ export function run(args, options = {}) {
   if (command === "next") {
     const explicitBump = readOption(commandArgs, "--bump")
     const message = readOption(commandArgs, "--message") ?? ""
-    stdout(nextVersion(readCurrentVersion(repoRoot), releaseBump(explicitBump, message)))
+    const currentVersion = readCurrentVersion(repoRoot)
+    stdout(nextVersion(currentVersion, releaseBump(explicitBump, message, currentVersion)))
   } else if (command === "apply") {
     applyVersion(requiredVersionArg(command, commandArgs), repoRoot)
   } else if (command === "check") {
@@ -44,7 +45,7 @@ export function readCurrentVersion(repoRoot = defaultRepoRoot) {
   return rootVersion
 }
 
-export function releaseBump(explicitBump, message) {
+export function releaseBump(explicitBump, message, currentVersion = "0.0.0") {
   if (explicitBump && explicitBump !== "auto") {
     if (!["current", "patch", "minor", "major"].includes(explicitBump)) {
       fail(`unsupported release bump ${explicitBump}`)
@@ -57,7 +58,27 @@ export function releaseBump(explicitBump, message) {
   if (message.includes("#minor")) {
     return "minor"
   }
+  if (hasBreakingChange(message)) {
+    // A breaking change below 1.0 raises the minor, which is how semver
+    // expresses it while the major is still zero. Reaching 1.0 stays a
+    // deliberate `#major` or a dispatch input.
+    return parseVersion(currentVersion).major === 0 ? "minor" : "major"
+  }
   return "patch"
+}
+
+/**
+ * Detects the two Conventional Commits breaking-change markers: a `!` before
+ * the colon of a `type(scope)!:` subject, and a `BREAKING CHANGE:` footer.
+ */
+export function hasBreakingChange(message) {
+  return message
+    .split("\n")
+    .some(
+      (line) =>
+        /^[a-z]+(?:\([^)]*\))?!:/u.test(line.trim()) ||
+        /^BREAKING[ -]CHANGE:/u.test(line.trim())
+    )
 }
 
 export function nextVersion(version, bump) {
@@ -278,9 +299,13 @@ function updateNpmLockfile(repoRoot, lockfilePath, version) {
   lockfile.packages[""].optionalDependencies ??= {}
   for (const { packageName } of nativeNpmPackages) {
     lockfile.packages[""].optionalDependencies[packageName] = version
-    // The release version does not exist on npm yet, so a package-lock refresh
-    // cannot resolve it. Keep an unresolved optional entry: npm ci accepts it,
-    // while a missing or stale entry makes the clean install fail before build.
+    // The release version does not exist on npm yet, so nothing here can carry
+    // a real resolved/integrity pair. Both an unresolved entry and a missing
+    // one fail `npm ci` once the version publishes ("does not satisfy" and
+    // "Missing: ... from lock file" respectively), so the release workflow
+    // refreshes this lockfile again after the native packages are published.
+    // Until that refresh lands, this placeholder only survives `npm ci`
+    // because the version is still absent from the registry.
     lockfile.packages[`node_modules/${packageName}`] = { optional: true }
   }
   writeJson(repoRoot, lockfilePath, lockfile)

--- a/scripts/release-version.test.mjs
+++ b/scripts/release-version.test.mjs
@@ -11,9 +11,53 @@ import {
   nextVersion,
   parseVersion,
   readCurrentVersion,
+  hasBreakingChange,
   releaseBump,
   run
 } from "./release-version.mjs"
+
+test("releaseBump treats Conventional Commits breaking markers as a version bump", () => {
+  // Below 1.0 a breaking change raises the minor; at or above 1.0 it raises the major.
+  assert.equal(releaseBump("auto", "feat(s3)!: make S3Vfs read-write", "0.4.8"), "minor")
+  assert.equal(releaseBump("auto", "feat(s3)!: make S3Vfs read-write", "1.2.3"), "major")
+  assert.equal(releaseBump("auto", "feat!: bare type", "0.4.8"), "minor")
+  assert.equal(releaseBump("auto", "feat: add thing\n\nBREAKING CHANGE: it moved", "0.4.8"), "minor")
+  assert.equal(releaseBump("auto", "feat: add thing\n\nBREAKING-CHANGE: it moved", "0.4.8"), "minor")
+
+  // A merge commit that hides the marker still falls back to patch, which is
+  // why the workflow feeds in every commit since the last release.
+  assert.equal(releaseBump("auto", "Merge pull request #12\n\nMake S3Vfs read-write", "0.4.8"), "patch")
+  assert.equal(releaseBump("auto", "fix: ordinary change", "0.4.8"), "patch")
+
+  // A footer marker must start its line, so prose naming it is not a bump.
+  assert.equal(releaseBump("auto", "docs: explain BREAKING CHANGE: footers", "0.4.8"), "patch")
+  assert.equal(releaseBump("auto", "fix: guard a!: token mid-sentence", "0.4.8"), "patch")
+
+  // Explicit markers and dispatch inputs still win.
+  assert.equal(releaseBump("auto", "feat!: x #major", "0.4.8"), "major")
+  assert.equal(releaseBump("patch", "feat!: x", "0.4.8"), "patch")
+})
+
+test("hasBreakingChange matches only real Conventional Commits markers", () => {
+  for (const message of [
+    "feat!: x",
+    "fix(scope)!: x",
+    "chore(deps)!: x",
+    "feat: x\n\nBREAKING CHANGE: y",
+    "feat: x\n\nBREAKING-CHANGE: y"
+  ]) {
+    assert.equal(hasBreakingChange(message), true, message)
+  }
+  for (const message of [
+    "feat: x",
+    "Merge pull request #12\n\nMake S3Vfs read-write",
+    "docs: describe BREAKING CHANGE: footers",
+    "fix: token a!: mid-sentence",
+    ""
+  ]) {
+    assert.equal(hasBreakingChange(message), false, message)
+  }
+})
 
 test("releaseBump uses dispatch input before commit-message markers", () => {
   // Manual releases must be deterministic even if the triggering commit carries a bump marker.
@@ -75,17 +119,27 @@ test("applyVersion updates Rust, npm, and lockfile manifests in lockstep", (t) =
   }
 })
 
-test("release-versioned optional packages support a clean npm install before publication", (t) => {
+test("placeholder optional entries only survive npm ci while the version is unpublished", (t) => {
   const repoRoot = createFixtureRepo(t)
   const nodeRoot = join(repoRoot, "tinysandbox-node")
 
+  // 1.4.0 does not exist on npm, so the placeholder entries `applyVersion`
+  // writes are accepted: npm cannot resolve the optional packages at all.
   applyVersion("1.4.0", repoRoot)
-
   execFileSync(
     process.platform === "win32" ? "npm.cmd" : "npm",
     ["ci", "--ignore-scripts", "--no-audit", "--no-fund", "--cache", join(repoRoot, ".npm-cache")],
     { cwd: nodeRoot, stdio: "pipe" }
   )
+
+  // This is the whole reason the release workflow refreshes the lockfile after
+  // publishing. Once the version resolves, the same placeholders fail the
+  // clean install, which is what broke CI after 0.4.7 and 0.4.8 shipped.
+  const lockfilePath = join(nodeRoot, "package-lock.json")
+  const lockfile = JSON.parse(readFileSync(lockfilePath, "utf8"))
+  for (const name of nativePackageNames) {
+    assert.deepEqual(lockfile.packages[`node_modules/${name}`], { optional: true })
+  }
 })
 
 test("checkVersion rejects lockstep disagreement", (t) => {

--- a/tinysandbox-node/Cargo.toml
+++ b/tinysandbox-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tinysandbox-node"
-version = "0.4.9"
+version = "0.4.8"
 edition = "2024"
 license = "MIT OR Apache-2.0"
 publish = false
@@ -16,7 +16,7 @@ napi-derive = "3"
 serde = { version = "1", features = ["derive"] }
 serde_bytes = "0.11"
 serde_json = "1"
-tinysandbox = { version = "0.4.9", path = "..", features = ["s3"] }
+tinysandbox = { version = "0.4.8", path = "..", features = ["s3"] }
 tokio = { version = "1", features = ["rt-multi-thread", "io-util", "time"] }
 
 [build-dependencies]

--- a/tinysandbox-node/native.cjs
+++ b/tinysandbox-node/native.cjs
@@ -2,7 +2,7 @@
 
 const { readFileSync } = require('node:fs')
 
-const packageVersion = '0.4.9'
+const packageVersion = '0.4.8'
 const loadErrors = []
 
 function isMusl() {

--- a/tinysandbox-node/npm/darwin-arm64/package.json
+++ b/tinysandbox-node/npm/darwin-arm64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinysandbox/tinysandbox-darwin-arm64",
-  "version": "0.4.9",
+  "version": "0.4.8",
   "cpu": [
     "arm64"
   ],

--- a/tinysandbox-node/npm/darwin-x64/package.json
+++ b/tinysandbox-node/npm/darwin-x64/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinysandbox/tinysandbox-darwin-x64",
-  "version": "0.4.9",
+  "version": "0.4.8",
   "cpu": [
     "x64"
   ],

--- a/tinysandbox-node/npm/linux-arm64-gnu/package.json
+++ b/tinysandbox-node/npm/linux-arm64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinysandbox/tinysandbox-linux-arm64-gnu",
-  "version": "0.4.9",
+  "version": "0.4.8",
   "cpu": [
     "arm64"
   ],

--- a/tinysandbox-node/npm/linux-x64-gnu/package.json
+++ b/tinysandbox-node/npm/linux-x64-gnu/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinysandbox/tinysandbox-linux-x64-gnu",
-  "version": "0.4.9",
+  "version": "0.4.8",
   "cpu": [
     "x64"
   ],

--- a/tinysandbox-node/package-lock.json
+++ b/tinysandbox-node/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tinysandbox/tinysandbox",
-  "version": "0.4.9",
+  "version": "0.4.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tinysandbox/tinysandbox",
-      "version": "0.4.9",
+      "version": "0.4.8",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "@napi-rs/cli": "^3.7.2",
@@ -18,10 +18,10 @@
         "node": ">=20"
       },
       "optionalDependencies": {
-        "@tinysandbox/tinysandbox-darwin-arm64": "0.4.9",
-        "@tinysandbox/tinysandbox-darwin-x64": "0.4.9",
-        "@tinysandbox/tinysandbox-linux-arm64-gnu": "0.4.9",
-        "@tinysandbox/tinysandbox-linux-x64-gnu": "0.4.9"
+        "@tinysandbox/tinysandbox-darwin-arm64": "0.4.8",
+        "@tinysandbox/tinysandbox-darwin-x64": "0.4.8",
+        "@tinysandbox/tinysandbox-linux-arm64-gnu": "0.4.8",
+        "@tinysandbox/tinysandbox-linux-x64-gnu": "0.4.8"
       }
     },
     "node_modules/@emnapi/core": {
@@ -2054,16 +2054,74 @@
       }
     },
     "node_modules/@tinysandbox/tinysandbox-darwin-arm64": {
-      "optional": true
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@tinysandbox/tinysandbox-darwin-arm64/-/tinysandbox-darwin-arm64-0.4.8.tgz",
+      "integrity": "sha512-Iqq8S3eDEbr+URaUrwaJ7c/sfGQHJ0I72l3mGaNGTIeTMMXg4m/vFZm61SxfrmkBRCFkFb5IXHR90IazSwFTyQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@tinysandbox/tinysandbox-darwin-x64": {
-      "optional": true
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@tinysandbox/tinysandbox-darwin-x64/-/tinysandbox-darwin-x64-0.4.8.tgz",
+      "integrity": "sha512-6aJqIzJqyOzJc6+tEHpqjKuHL8P6u2vk9skQOo4M91haX7sbJJggxKDwzQRKS5kA6DPBA1VxrKoQuqWq+sM3Wg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@tinysandbox/tinysandbox-linux-arm64-gnu": {
-      "optional": true
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@tinysandbox/tinysandbox-linux-arm64-gnu/-/tinysandbox-linux-arm64-gnu-0.4.8.tgz",
+      "integrity": "sha512-tPLJoMhXVWubdZICtr9VtnMikLGcgbtvsUhUBU/DRRQ9MOUrcyWLO8CABtE74FJdl92Z5+7k06md+mDzFmRvkA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@tinysandbox/tinysandbox-linux-x64-gnu": {
-      "optional": true
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@tinysandbox/tinysandbox-linux-x64-gnu/-/tinysandbox-linux-x64-gnu-0.4.8.tgz",
+      "integrity": "sha512-svIDnVYC/cSFv4+/xpY0PHI0hYDIu1pkOccaldSmgb3fa9BrgbkxMxxR9wMQf1+mWt7YWFyG4jtU1cDvs5/oeQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",

--- a/tinysandbox-node/package.json
+++ b/tinysandbox-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinysandbox/tinysandbox",
-  "version": "0.4.9",
+  "version": "0.4.8",
   "description": "Node.js bindings for the tinysandbox in-process AI agent sandbox",
   "main": "index.js",
   "types": "index.d.ts",
@@ -39,10 +39,10 @@
     "tsx": "^4.23.0"
   },
   "optionalDependencies": {
-    "@tinysandbox/tinysandbox-darwin-arm64": "0.4.9",
-    "@tinysandbox/tinysandbox-darwin-x64": "0.4.9",
-    "@tinysandbox/tinysandbox-linux-arm64-gnu": "0.4.9",
-    "@tinysandbox/tinysandbox-linux-x64-gnu": "0.4.9"
+    "@tinysandbox/tinysandbox-darwin-arm64": "0.4.8",
+    "@tinysandbox/tinysandbox-darwin-x64": "0.4.8",
+    "@tinysandbox/tinysandbox-linux-arm64-gnu": "0.4.8",
+    "@tinysandbox/tinysandbox-linux-x64-gnu": "0.4.8"
   },
   "files": [
     "README.md",


### PR DESCRIPTION
Two bugs in the release tooling, both surfaced by the `0.4.9` release that merging #12 triggered. That release was cancelled before its publish step ran, so nothing reached crates.io or npm.

## 1. Version selection ignored the commits

`releaseBump` only looked for the literal strings `#major` / `#minor`. A commit with `feat(s3)!:` and a `BREAKING CHANGE:` footer still cut a patch release, so a breaking change was about to ship as `0.4.9`.

It now recognizes both Conventional Commits breaking markers — `type(scope)!:` and a `BREAKING CHANGE:` / `BREAKING-CHANGE:` footer — raising the minor below `1.0` and the major at or above it. `#major`/`#minor` and workflow dispatch inputs still take precedence, and a footer must start its line so prose naming it is not a bump.

There was a second half to this: the workflow read only the head commit, and on a merge that's the merge subject plus the PR title, not the `feat(s3)!:` commit underneath. Eligibility still reads the head commit alone (so `[skip release]` works), but version selection now reads every commit since the last release.

Verified against the exact range that just released:

```
$ node scripts/release-version.mjs next --bump auto --message "$(git log --format=%B 522ae59..62937cd)"
0.5.0
$ node scripts/release-version.mjs next --bump auto --message "$(git log -1 --format=%B 62937cd)"   # old behavior
0.4.9
```

## 2. The lockfile placeholders break `npm ci` one release later

`applyVersion` cannot write a real `resolved`/`integrity` pair, because the version being released does not exist on npm when the release commit is built. It leaves `{"optional": true}` placeholders, and the comment claimed `npm ci` accepts them.

It does — but only while the version is unpublished. I reproduced all three shapes against a version that *is* published:

| Lock entry shape | `npm ci`, version unpublished | `npm ci`, version published |
|---|---|---|
| `{"optional": true}` placeholder | passes | **fails** — `Invalid: ...@ does not satisfy ...@0.4.8` |
| entry omitted entirely | passes | **fails** — `Missing: ...@0.4.8 from lock file` |
| real `version`/`resolved`/`integrity` | n/a | passes |

So the release commit looks green the moment it lands and poisons the *next* pull request's CI. That is what happened after `0.4.7` (repaired by hand in 02657a1) and again after `0.4.8` (repaired in b940845 on #12). Neither was a one-off.

The publish job now refreshes the lockfile with `npm install --package-lock-only` after the native packages publish and pushes it to main, which is mechanically what both manual repairs did.

The existing test is why this kept slipping through: it applied a fictional `1.4.0` and ran `npm ci`, which passes precisely because `1.4.0` was never published. It only ever covered the window where the bug is invisible. Renamed to say so, and it now asserts the placeholder shape it leaves behind.

## 3. Reverts the phantom 0.4.9 bump

`prepare` pushed `chore(release): 0.4.9` to main before the cancel landed, so the manifests claimed a version that does not exist on either registry. Reverted to `0.4.8`, which also restores the correct lockfile entries.

## Verification

- `node --test scripts/release-version.test.mjs scripts/release-native-artifacts.test.mjs scripts/verify-glibc-baseline.test.mjs` — 21/21
- New tests cover breaking-marker detection, the pre-1.0 vs post-1.0 split, merge-commit fallback, prose false positives, and precedence of explicit markers
- `npm ci` succeeds on the reverted lockfile
- `node scripts/release-version.mjs check "$(node scripts/release-version.mjs next --bump current)"` passes at `0.4.8`

## After this merges

This PR is itself a `fix:` with no breaking marker, so it will release as a patch. The writable-S3 change still needs its minor — dispatch Release with `bump: minor` to cut `0.5.0` once this is in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
