### PR TITLE
Match release markers as standalone tokens, and cut the writable-S3 minor #minor

### DIFF
--- a/scripts/release-version.mjs
+++ b/scripts/release-version.mjs
@@ -52,10 +52,10 @@ export function releaseBump(explicitBump, message, currentVersion = "0.0.0") {
     }
     return explicitBump
   }
-  if (message.includes("#major")) {
+  if (hasReleaseMarker(message, "major")) {
     return "major"
   }
-  if (message.includes("#minor")) {
+  if (hasReleaseMarker(message, "minor")) {
     return "minor"
   }
   if (hasBreakingChange(message)) {
@@ -65,6 +65,14 @@ export function releaseBump(explicitBump, message, currentVersion = "0.0.0") {
     return parseVersion(currentVersion).major === 0 ? "minor" : "major"
   }
   return "patch"
+}
+
+/**
+ * Matches `#major`/`#minor` only as a standalone token, so a commit that writes
+ * about the markers does not request the bump it is describing.
+ */
+export function hasReleaseMarker(message, marker) {
+  return new RegExp(String.raw`(?:^|\s)#${marker}(?=[\s.,;:!?)]|$)`, "mu").test(message)
 }
 
 /**

--- a/scripts/release-version.test.mjs
+++ b/scripts/release-version.test.mjs
@@ -12,6 +12,7 @@ import {
   parseVersion,
   readCurrentVersion,
   hasBreakingChange,
+  hasReleaseMarker,
   releaseBump,
   run
 } from "./release-version.mjs"
@@ -57,6 +58,23 @@ test("hasBreakingChange matches only real Conventional Commits markers", () => {
   ]) {
     assert.equal(hasBreakingChange(message), false, message)
   }
+})
+
+test("release markers are recognized only as standalone tokens", () => {
+  assert.equal(hasReleaseMarker("ship it #minor", "minor"), true)
+  assert.equal(hasReleaseMarker("#major", "major"), true)
+  assert.equal(hasReleaseMarker("subject\n\n#major\n", "major"), true)
+  assert.equal(hasReleaseMarker("cut it #minor.", "minor"), true)
+
+  // A commit that documents the markers must not request the bump it names.
+  // The 0.4.9 release computed 1.0.0 from a commit body that wrote `#major`.
+  assert.equal(hasReleaseMarker("uses literal `#major`/`#minor` markers", "major"), false)
+  assert.equal(hasReleaseMarker("uses literal `#major`/`#minor` markers", "minor"), false)
+  assert.equal(hasReleaseMarker("foo#minor", "minor"), false)
+  assert.equal(hasReleaseMarker("#minority report", "minor"), false)
+
+  assert.equal(releaseBump("auto", "docs: explain `#major` handling", "0.4.8"), "patch")
+  assert.equal(releaseBump("auto", "chore: cut it #major", "0.4.8"), "major")
 })
 
 test("releaseBump uses dispatch input before commit-message markers", () => {


### PR DESCRIPTION
Answering the question directly: **yes, you have to wait — and merging anything right now would have made it worse.** Two separate problems, both now understood.

## What the pending release was about to do

I cancelled main's CI run again, because with #13 merged the release was going to cut **1.0.0**.

The cause is my own commit message from #13. `releaseBump` tested the message with `includes`, and that commit *documents* marker handling:

```
literal `#major`/`#minor` markers, so `feat(s3)!:` with a
```

A commit describing the markers requested the bump it was describing. This is pre-existing fragility — my commit is just the first that ever wrote those strings into a message.

This PR anchors the match: a marker counts only as a standalone token, preceded by start-of-line or whitespace and followed by whitespace, terminating punctuation, or end-of-line.

| Message | Before | After |
|---|---|---|
| `ship it #minor` | minor | minor |
| ``literal `#major`/`#minor` markers`` | **major** | patch |
| `#minority report` | **minor** | patch |
| `cut it #major` | major | major |

## Why 0.5.0 will not happen on its own

Even with that fixed, the auto-release computes `0.4.9`:

```
$ node scripts/release-version.mjs next --bump auto --message "$(git log --format=%B f117768..origin/main)"
0.4.9
```

The cancelled `0.4.9` attempt still left `chore(release): 0.4.9 [skip release]` in history, and #13 taught the workflow to read commits *since the last release commit*. That phantom commit now sits between `feat(s3)!:` and HEAD, so the breaking marker is behind the barrier and invisible. Reverting its contents did not remove it from the log.

So the S3 breaking change would ship as a patch — the exact outcome we cancelled the first release to avoid.

## How this PR gets you to 0.5.0

The title carries a standalone `#minor`, which becomes the merge commit body. That is the one intentional marker, and it clears the barrier:

```
$ node scripts/release-version.mjs next --bump auto --message "<range> + merge commit with #minor"
0.5.0
```

**Merge this with the default merge commit message and the release cuts `0.5.0`** — covering the writable S3 VFS, the release tooling fixes, and this one. No dispatch, no third cancel. If you edit the merge message, keep `#minor` in it as its own word.

The post-publish lockfile refresh from #13 is already on main, so this release should also be the first one that leaves `package-lock.json` resolved on its own.

## Verification

- `node --test scripts/release-version.test.mjs` — 10/10, including the exact backticked string that produced 1.0.0
- This PR's own commit message quotes the markers in backticks and computes `patch`, which is the regression test running in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)
