### PR TITLE
Resolve every native lockfile entry before committing it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         run: npm install -g npm@12.0.2
       - name: Check release scripts and native matrix
         run: |
-          node --test scripts/release-version.test.mjs scripts/release-native-artifacts.test.mjs scripts/verify-glibc-baseline.test.mjs
+          node --test scripts/release-version.test.mjs scripts/release-native-artifacts.test.mjs scripts/refresh-native-lockfile.test.mjs scripts/verify-glibc-baseline.test.mjs
           node scripts/release-version.mjs check "$(node scripts/release-version.mjs next --bump current)"
       - run: cargo fmt --all --check
       - run: cargo test --workspace --all-features --locked

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -443,8 +443,11 @@ jobs:
           # `release-version.mjs apply` can only leave placeholder entries for
           # the native packages, because the version does not exist on npm when
           # the release commit is built. They resolve now that publishing is
-          # done, and `npm ci` rejects the placeholders until they do.
-          npm install --package-lock-only --no-audit --no-fund --prefix tinysandbox-node
+          # done, and `npm ci` rejects the placeholders until they do. The
+          # refresh retries while the registry catches up with the packages this
+          # run just published, and fails the release rather than committing a
+          # lockfile that would break `npm ci` on main.
+          node scripts/refresh-native-lockfile.mjs "${VERSION}"
           if git diff --quiet -- tinysandbox-node/package-lock.json; then
             echo "lockfile already resolves ${VERSION}"
             exit 0

--- a/scripts/refresh-native-lockfile.mjs
+++ b/scripts/refresh-native-lockfile.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+// Resolves the placeholder entries `release-version.mjs apply` leaves for the
+// native npm packages, once those packages are published.
+//
+// `npm install --package-lock-only` drops an entry it cannot resolve rather
+// than leaving the placeholder, and the package published last is the one the
+// registry has not made readable yet, so a single pass can silently produce a
+// lockfile that fails `npm ci` for everyone. Refreshing until the lockfile
+// passes `release-version.mjs check` keeps that failure inside the release.
+import { execFileSync } from "node:child_process"
+import { fileURLToPath } from "node:url"
+
+const defaultRepoRoot = process.env.RELEASE_REPO_ROOT ?? fileURLToPath(new URL("..", import.meta.url))
+
+export const defaultAttempts = 5
+export const defaultWaitMs = 15_000
+
+export async function refreshNativeLockfile(version, options = {}) {
+  const attempts = options.attempts ?? defaultAttempts
+  const waitMs = options.waitMs ?? defaultWaitMs
+  const repoRoot = options.repoRoot ?? defaultRepoRoot
+  const log = options.log ?? console.log
+  const install = options.install ?? ((root) => npmInstall(root))
+  const check = options.check ?? ((root, target) => releaseCheck(root, target))
+  const sleep = options.sleep ?? ((ms) => new Promise((done) => setTimeout(done, ms)))
+
+  let lastError
+  for (let attempt = 1; attempt <= attempts; attempt += 1) {
+    install(repoRoot)
+    try {
+      check(repoRoot, version)
+      return attempt
+    } catch (error) {
+      lastError = error
+      if (attempt < attempts) {
+        log(`lockfile does not resolve ${version} yet (attempt ${attempt}); waiting for the registry`)
+        await sleep(waitMs)
+      }
+    }
+  }
+  throw new Error(
+    `tinysandbox-node/package-lock.json still does not resolve ${version} after ${attempts} attempts: ${lastError?.message ?? "unknown error"}`
+  )
+}
+
+// `--prefer-online` stops npm answering from cached registry metadata that
+// predates the packages this release just published.
+function npmInstall(repoRoot) {
+  execFileSync(
+    "npm",
+    [
+      "install",
+      "--package-lock-only",
+      "--prefer-online",
+      "--no-audit",
+      "--no-fund",
+      "--prefix",
+      "tinysandbox-node"
+    ],
+    { cwd: repoRoot, stdio: "inherit" }
+  )
+}
+
+function releaseCheck(repoRoot, version) {
+  execFileSync("node", ["scripts/release-version.mjs", "check", version], {
+    cwd: repoRoot,
+    stdio: "inherit"
+  })
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const version = process.argv[2]
+  if (!version) {
+    console.error("usage: refresh-native-lockfile.mjs <version>")
+    process.exit(1)
+  }
+  try {
+    const attempts = await refreshNativeLockfile(version)
+    console.log(`lockfile resolves ${version} after ${attempts} attempt(s)`)
+  } catch (error) {
+    console.error(error.message)
+    process.exit(1)
+  }
+}

--- a/scripts/refresh-native-lockfile.test.mjs
+++ b/scripts/refresh-native-lockfile.test.mjs
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict"
+import { readFileSync } from "node:fs"
+import { test } from "node:test"
+
+import { defaultAttempts, refreshNativeLockfile } from "./refresh-native-lockfile.mjs"
+
+const releaseWorkflow = readFileSync(new URL("../.github/workflows/release.yml", import.meta.url), "utf8")
+const ciWorkflow = readFileSync(new URL("../.github/workflows/ci.yml", import.meta.url), "utf8")
+
+function harness({ failuresBeforeSuccess = 0 } = {}) {
+  const calls = { installs: 0, checks: 0, waits: [] }
+  return {
+    calls,
+    options: {
+      attempts: defaultAttempts,
+      waitMs: 15_000,
+      repoRoot: "/nowhere",
+      log: () => {},
+      install: () => {
+        calls.installs += 1
+      },
+      check: () => {
+        calls.checks += 1
+        if (calls.checks <= failuresBeforeSuccess) {
+          throw new Error("missing the optional package entry")
+        }
+      },
+      sleep: async (ms) => {
+        calls.waits.push(ms)
+      }
+    }
+  }
+}
+
+test("a lockfile that already resolves needs one pass and no waiting", async () => {
+  const { calls, options } = harness()
+  assert.equal(await refreshNativeLockfile("0.6.0", options), 1)
+  assert.deepEqual(calls, { installs: 1, checks: 1, waits: [] })
+})
+
+test("a registry that catches up mid-retry resolves without failing the release", async () => {
+  // The package published last is readable a few seconds after the others, so
+  // the refresh has to run again rather than commit what npm gave it.
+  const { calls, options } = harness({ failuresBeforeSuccess: 2 })
+  assert.equal(await refreshNativeLockfile("0.6.0", options), 3)
+  assert.equal(calls.installs, 3)
+  assert.deepEqual(calls.waits, [15_000, 15_000])
+})
+
+test("a lockfile that never resolves fails the release instead of shipping", async () => {
+  const { calls, options } = harness({ failuresBeforeSuccess: Number.POSITIVE_INFINITY })
+  await assert.rejects(refreshNativeLockfile("0.6.0", options), /still does not resolve 0\.6\.0 after 5 attempts/u)
+  assert.equal(calls.installs, defaultAttempts)
+  // The last attempt does not wait: nothing would look at the result.
+  assert.equal(calls.waits.length, defaultAttempts - 1)
+})
+
+test("the release workflow refreshes through this script", () => {
+  assert.match(releaseWorkflow, /node scripts\/refresh-native-lockfile\.mjs "\$\{VERSION\}"/u)
+})
+
+test("CI runs these tests with the other release gates", () => {
+  assert.match(ciWorkflow, /scripts\/refresh-native-lockfile\.test\.mjs/u)
+})

--- a/tinysandbox-node/package-lock.json
+++ b/tinysandbox-node/package-lock.json
@@ -2104,6 +2104,25 @@
         "node": ">=20"
       }
     },
+    "node_modules/@tinysandbox/tinysandbox-linux-x64-gnu": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@tinysandbox/tinysandbox-linux-x64-gnu/-/tinysandbox-linux-x64-gnu-0.6.0.tgz",
+      "integrity": "sha512-RQJkBP6j5ZXyTFQilkIrgfFzqu9pvhSTqP1ME7NnstnLDOw5c2DyEhbb0A1sMjgohPPRtEDbRSeKkCtFBkq/RA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT OR Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",


### PR DESCRIPTION
`npm ci` fails on `main` right now:

```
npm error Missing: @tinysandbox/tinysandbox-linux-x64-gnu@0.6.0 from lock file
```

Same failure shipped with 0.5.0, and `rust-release-gates` reports it as "package-lock.json is missing the optional package entry" on every branch until someone regenerates the lockfile by hand.

## Cause

`release-version.mjs apply` writes placeholder entries (`{ optional: true }`) for the four native packages, because the release version does not exist on npm when the release commit is built. The release job then runs `npm install --package-lock-only` to resolve them. When npm cannot resolve one, it **deletes the placeholder** instead of leaving it, and the package it cannot resolve is whichever was published most recently — `linux-x64-gnu` is last in the publish loop, seconds before the refresh runs. Nothing validated the refreshed lockfile, so the bad version was committed to main and only surfaced on the next PR's CI.

## Fix

`scripts/refresh-native-lockfile.mjs` reruns the install until the lockfile passes `release-version.mjs check` — the gate that already knows this exact condition — and fails the release if it never resolves. `--prefer-online` stops npm answering from cached registry metadata that predates this run's publishes.

The check runs on the artifact itself rather than a proxy like `npm view`, so a partially-propagated registry cannot satisfy it, and the release job now fails loudly instead of committing a lockfile that breaks every branch.

Also regenerates the 0.6.0 lockfile, which restores `npm ci` on main.

## Testing

`scripts/refresh-native-lockfile.test.mjs` covers the three paths — resolves on the first pass with no waiting, resolves mid-retry as the registry catches up, and gives up after five attempts without committing — plus assertions that both workflows are wired to the script. CI runs it alongside the other release-gate tests.

Verified end to end against the live registry: `node scripts/refresh-native-lockfile.mjs 0.6.0` resolves all four entries on the first attempt, and `npm ci` succeeds afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)