### PR TITLE
Fix native release lockfile rebase race

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,15 @@ jobs:
             echo "main advanced before the release commit could be pushed; rebasing release commit (attempt ${attempt})"
             git fetch origin main
             git rebase origin/main
+            # A preceding release can refresh its optional native-package
+            # lockfile entries while this release is preparing. Reapplying the
+            # version after the rebase replaces those now-stale resolved entries
+            # with placeholders for the version that has not been published yet.
+            node scripts/release-version.mjs apply "${{ steps.version.outputs.version }}"
+            cargo update -w
+            node scripts/release-version.mjs check "${{ steps.version.outputs.version }}"
+            git add Cargo.toml Cargo.lock tinysandbox-node/Cargo.toml tinysandbox-node/package.json tinysandbox-node/package-lock.json tinysandbox-node/native.cjs tinysandbox-node/npm/*/package.json
+            git commit --amend --no-edit
           done
           git push origin HEAD:main
 

--- a/scripts/release-native-artifacts.test.mjs
+++ b/scripts/release-native-artifacts.test.mjs
@@ -156,6 +156,23 @@ test("release versioning preserves unpublished optional packages and uses OIDC p
   assert.doesNotMatch(workflow, /NPM_TOKEN|NODE_AUTH_TOKEN/)
 })
 
+test("release preparation repairs versioned files after rebasing onto main", () => {
+  const retry = workflow.match(
+    /git fetch origin main\n(?<body>[\s\S]*?)\n\s+done/
+  )?.groups?.body
+  assert.ok(retry, "release workflow must define a push retry after fetching main")
+  assert.match(retry, /git rebase origin\/main/)
+  assert.match(
+    retry,
+    /node scripts\/release-version\.mjs apply "\$\{\{ steps\.version\.outputs\.version \}\}"/
+  )
+  assert.match(
+    retry,
+    /node scripts\/release-version\.mjs check "\$\{\{ steps\.version\.outputs\.version \}\}"/
+  )
+  assert.match(retry, /git commit --amend --no-edit/)
+})
+
 test("portable JS runtime publishes independently after successful main CI", () => {
   const job = workflow.match(
     /\n  publish-portable-js-runtime:\n(?<body>[\s\S]*?)\n  build-linux-native:/

--- a/tinysandbox-node/package-lock.json
+++ b/tinysandbox-node/package-lock.json
@@ -2054,74 +2054,16 @@
       }
     },
     "node_modules/@tinysandbox/tinysandbox-darwin-arm64": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@tinysandbox/tinysandbox-darwin-arm64/-/tinysandbox-darwin-arm64-0.6.3.tgz",
-      "integrity": "sha512-m+PLuc9tHwjn6VmJ1QW9LJcd9HfKhIJKWmPK3VxVPnwhcpyItNWj80WUEUXKIOidmr7wrr3ru2oJYdcyVXbt7Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=20"
-      }
+      "optional": true
     },
     "node_modules/@tinysandbox/tinysandbox-darwin-x64": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@tinysandbox/tinysandbox-darwin-x64/-/tinysandbox-darwin-x64-0.6.3.tgz",
-      "integrity": "sha512-MHDHPD15AY0zkSHpPSEgQA+Z/2U7hT40PHMdZuNsstPJfscy5Yg7czlbk7+HBKWmGH1pRpkBRjpSvTMy/78GeA==",
-      "cpu": [
-        "x64"
-      ],
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=20"
-      }
+      "optional": true
     },
     "node_modules/@tinysandbox/tinysandbox-linux-arm64-gnu": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@tinysandbox/tinysandbox-linux-arm64-gnu/-/tinysandbox-linux-arm64-gnu-0.6.3.tgz",
-      "integrity": "sha512-aMnyRFICaIBYYRdbXhFlvqIMvWuSX76l7doQOpQd2E0D5KLcYjs1NbdMU+XYp2GNm+T3HxxtY+Gqs+Udmz9HRg==",
-      "cpu": [
-        "arm64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=20"
-      }
+      "optional": true
     },
     "node_modules/@tinysandbox/tinysandbox-linux-x64-gnu": {
-      "version": "0.6.3",
-      "resolved": "https://registry.npmjs.org/@tinysandbox/tinysandbox-linux-x64-gnu/-/tinysandbox-linux-x64-gnu-0.6.3.tgz",
-      "integrity": "sha512-tQSu/Vhrt5LQSzvqUZgqb3SiEMsdnXlxgzEXWht/+5C2ulHJx7alTTkG/irAhjKN3VYUe+waiRf8EkEmMMLNzg==",
-      "cpu": [
-        "x64"
-      ],
-      "libc": [
-        "glibc"
-      ],
-      "license": "MIT OR Apache-2.0",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=20"
-      }
+      "optional": true
     },
     "node_modules/@tybys/wasm-util": {
       "version": "0.10.3",


### PR DESCRIPTION
## Summary

- repair the failed 0.6.4 lockfile so its optional native-package entries no longer resolve 0.6.3
- reapply and verify the target version after a release commit rebases onto an advanced `main`
- add a regression test covering the push-retry repair

## Root cause

The 0.6.4 release prepared while the previous 0.6.3 publisher was refreshing its lockfile on `main`. The push retry rebased the 0.6.4 release commit over that refresh, which silently restored resolved 0.6.3 optional-package entries. npm 12 then rejected the 0.6.4 manifest/lockfile mismatch in all four native build jobs. The portable JS runtime publish job completed successfully.

## Verification

- `node --test scripts/release-version.test.mjs scripts/release-native-artifacts.test.mjs scripts/refresh-native-lockfile.test.mjs scripts/verify-glibc-baseline.test.mjs` — 31 passing
- `node scripts/release-version.mjs check "$(node scripts/release-version.mjs next --bump current)"`
- `npx --yes npm@12.0.2 ci --ignore-scripts --no-audit --no-fund` in `tinysandbox-node`