### PR TITLE
Add a browser QuickJS/WASM playground

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /target
 node_modules
 *.node
+/tinysandbox-js-runtime/site-dist/

--- a/README.md
+++ b/README.md
@@ -325,7 +325,10 @@ synchronous VFS additionally enables `runFile()`, the supported `fs` subset,
 filesystem capability. The package does not include the shell, coreutils,
 native bindings, a concrete storage backend, or ambient network access. Its
 [package README](tinysandbox-js-runtime/README.md) documents the small API and
-host examples.
+host examples. A minimal
+[browser playground](tinysandbox-js-runtime/examples/browser/index.html) runs
+editable source in the wasm guest and shows console output, the return value,
+and peak linear memory side by side.
 
 Not there on purpose: timers, an event loop, direct networking,
 `child_process`/process spawning, built-in shell command execution from

--- a/tinysandbox-js-runtime/README.md
+++ b/tinysandbox-js-runtime/README.md
@@ -70,7 +70,7 @@ The site is entirely static. In a Cloudflare Pages Git integration, use:
 | --- | --- |
 | Framework preset | `None` |
 | Root directory | `tinysandbox-js-runtime` |
-| Build command | `npm ci && npm run build:site` |
+| Build command | `npm run build:site` |
 | Build output directory | `site-dist` |
 
 No environment variables, Pages Functions, Wrangler configuration, or separate

--- a/tinysandbox-js-runtime/README.md
+++ b/tinysandbox-js-runtime/README.md
@@ -43,6 +43,40 @@ const result = engine.runCode("console.log(context.value(null))", {
 });
 ```
 
+## Browser playground
+
+The package includes a minimal two-pane
+[browser example](examples/browser/index.html) that displays guest console
+output, the evaluated script's return value, exit status, elapsed time, and
+initial/peak wasm linear memory. It deliberately ends with an expression so
+the example can capture that value through a synchronous custom global; the
+browser never evaluates the source itself.
+
+From this directory in either a source checkout or the unpacked package:
+
+```sh
+npm run example:browser
+```
+
+Then open `http://127.0.0.1:4173/`. The default script prints that `window` and
+`document` are unavailable inside the guest. Each click creates the same fresh,
+bounded QuickJS/WASM instance as a direct `runCode()` call.
+
+### Cloudflare Pages
+
+The site is entirely static. In a Cloudflare Pages Git integration, use:
+
+| Setting | Value |
+| --- | --- |
+| Framework preset | `None` |
+| Root directory | `tinysandbox-js-runtime` |
+| Build command | `npm ci && npm run build:site` |
+| Build output directory | `site-dist` |
+
+No environment variables, Pages Functions, Wrangler configuration, or separate
+deployment workflow are required. `build:site` creates a clean output directory
+containing only the playground, `runtime.js`, and `quickjs.wasm`.
+
 `runCode(code, options)` returns `exitCode`, UTF-8 `stdout` and `stderr`, and
 initial/peak wasm memory bytes. Its defaults are a 64 MiB wasm maximum, 32 MiB
 QuickJS heap, 30 second monotonic deadline, and 1 MiB each for source, serialized

--- a/tinysandbox-js-runtime/examples/browser/index.html
+++ b/tinysandbox-js-runtime/examples/browser/index.html
@@ -1,25 +1,335 @@
 <!doctype html>
-<meta charset="utf-8">
-<title>tinysandbox JS runtime smoke</title>
-<pre id="result">RUNNING</pre>
-<script type="module">
-  import { createEngine } from "../../dist/index.js";
-  import { TestVfs } from "../../test/test-vfs.mjs";
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>tinysandbox · QuickJS/WASM playground</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --background: #10110f;
+      --panel: #161714;
+      --text: #e8eadf;
+      --muted: #92968a;
+      --line: #34372f;
+      --accent: #c4f36b;
+      --error: #ff8b7d;
+    }
 
-  const wasm = await fetch("../../quickjs.wasm").then(response => response.arrayBuffer());
-  const engine = await createEngine(wasm);
-  const result = engine.runCode("console.log(greet({ name: 'browser' }))", {
-    globals: { greet: ({ name }) => `hello ${name}` },
-  });
-  const vfs = new TestVfs({
-    "/app/main.js": "console.log(__filename, require('./message').text)",
-    "/app/message.js": "exports.text = require('fs').readFileSync('./value', 'utf8')",
-    "/app/value": "from-vfs",
-  });
-  const file = engine.runFile("main.js", { vfs, cwd: "/app" });
-  document.querySelector("#result").textContent =
-    result.exitCode === 0 && result.stdout === "hello browser\n" &&
-    file.exitCode === 0 && file.stdout === "/app/main.js from-vfs\n"
-      ? "PASS"
-      : JSON.stringify({ result, file });
-</script>
+    * { box-sizing: border-box; }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: var(--background);
+      color: var(--text);
+      font: 14px/1.5 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+    }
+
+    main {
+      width: min(1180px, 100%);
+      margin: 0 auto;
+      padding: 28px;
+    }
+
+    header {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+      gap: 24px;
+      margin-bottom: 24px;
+    }
+
+    h1 {
+      margin: 0 0 6px;
+      font-size: clamp(18px, 3vw, 24px);
+      font-weight: 600;
+      letter-spacing: -0.04em;
+    }
+
+    p {
+      max-width: 760px;
+      margin: 0;
+      color: var(--muted);
+    }
+
+    .runtime {
+      flex: none;
+      border: 1px solid var(--line);
+      padding: 8px 10px;
+      color: var(--accent);
+      font-size: 11px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .workspace {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      border: 1px solid var(--line);
+      background: var(--panel);
+    }
+
+    section + section { border-left: 1px solid var(--line); }
+
+    .pane-header {
+      display: flex;
+      min-height: 45px;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+      padding: 8px 12px;
+      border-bottom: 1px solid var(--line);
+      color: var(--muted);
+      font-size: 11px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+    }
+
+    .actions { display: flex; gap: 8px; }
+
+    button {
+      border: 1px solid var(--line);
+      border-radius: 0;
+      padding: 6px 10px;
+      background: transparent;
+      color: var(--text);
+      font: inherit;
+      font-size: 11px;
+      text-transform: uppercase;
+      cursor: pointer;
+    }
+
+    button:hover:not(:disabled), button:focus-visible {
+      border-color: var(--accent);
+      color: var(--accent);
+      outline: none;
+    }
+
+    button:disabled { cursor: wait; opacity: 0.45; }
+    button.primary { background: var(--accent); color: #171a11; border-color: var(--accent); }
+    button.primary:hover:not(:disabled), button.primary:focus-visible { color: #171a11; filter: brightness(1.08); }
+
+    textarea {
+      display: block;
+      width: 100%;
+      height: min(62vh, 620px);
+      min-height: 360px;
+      resize: vertical;
+      border: 0;
+      border-radius: 0;
+      padding: 18px;
+      background: var(--panel);
+      color: var(--text);
+      font: inherit;
+      line-height: 1.65;
+      tab-size: 2;
+      outline: none;
+    }
+
+    textarea:focus { box-shadow: inset 0 0 0 1px var(--accent); }
+    textarea[readonly] { color: #c9ccbf; }
+
+    footer {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 8px 18px;
+      padding: 10px 12px;
+      border: 1px solid var(--line);
+      border-top: 0;
+      color: var(--muted);
+      font-size: 11px;
+      letter-spacing: 0.04em;
+      text-transform: uppercase;
+    }
+
+    #exit[data-state="ok"] { color: var(--accent); }
+    #exit[data-state="error"] { color: var(--error); }
+    kbd { color: var(--text); font: inherit; }
+
+    @media (max-width: 760px) {
+      main { padding: 18px; }
+      header { display: block; }
+      .runtime { display: inline-block; margin-top: 16px; }
+      .workspace { grid-template-columns: 1fr; }
+      section + section { border-left: 0; border-top: 1px solid var(--line); }
+      textarea { height: 42vh; min-height: 280px; }
+    }
+  </style>
+</head>
+<body data-runtime="quickjs-wasm">
+  <main>
+    <header>
+      <div>
+        <h1>tinysandbox / js</h1>
+        <p>Source runs in a fresh QuickJS instance inside WebAssembly. Browser globals, DOM, filesystem, and network capabilities are not exposed.</p>
+      </div>
+      <div class="runtime">host: V8 · guest: QuickJS/WASM</div>
+    </header>
+
+    <div class="workspace">
+      <section>
+        <div class="pane-header">
+          <span>input.js</span>
+          <div class="actions">
+            <button id="reset" type="button">reset</button>
+            <button class="primary" id="run" type="button" disabled>run</button>
+          </div>
+        </div>
+        <textarea id="source" aria-label="JavaScript source" autocomplete="off" autocorrect="off" autocapitalize="off" spellcheck="false"></textarea>
+      </section>
+
+      <section>
+        <div class="pane-header">
+          <span>output</span>
+          <span>console + return value</span>
+        </div>
+        <textarea id="output" aria-label="Execution output" readonly>Loading QuickJS WebAssembly…</textarea>
+      </section>
+    </div>
+
+    <footer aria-live="polite">
+      <span id="exit">loading wasm</span>
+      <span id="elapsed">time —</span>
+      <span id="memory">wasm peak —</span>
+      <span>limit 16 MiB</span>
+      <span><kbd>⌘/ctrl + enter</kbd> to run</span>
+    </footer>
+    <pre id="result" hidden>RUNNING</pre>
+  </main>
+
+  <script type="module">
+    import { createEngine } from "../../dist/index.js";
+
+    const MEMORY_LIMIT_BYTES = 16 * 1024 * 1024;
+    const DEFAULT_SOURCE = `console.log("hello from QuickJS");
+console.log("window:", typeof window);
+console.log("document:", typeof document);
+
+({ answer: 6 * 7, engine: "quickjs-wasm" });`;
+
+    const source = document.querySelector("#source");
+    const output = document.querySelector("#output");
+    const runButton = document.querySelector("#run");
+    const resetButton = document.querySelector("#reset");
+    const exit = document.querySelector("#exit");
+    const elapsed = document.querySelector("#elapsed");
+    const memory = document.querySelector("#memory");
+    const smoke = document.querySelector("#result");
+    source.value = DEFAULT_SOURCE;
+
+    let engine;
+    let firstRun = true;
+
+    function formatBytes(bytes) {
+      return `${(bytes / (1024 * 1024)).toFixed(2)} MiB`;
+    }
+
+    function guestProgram(userSource) {
+      // The browser only constructs this string. QuickJS evaluates it inside
+      // the wasm instance; browser eval() and Function() are never used.
+      return `(function () {
+  const capture = playground.capture;
+  const value = (0, eval)(${JSON.stringify(userSource)});
+  const type = value === null ? "null" : typeof value;
+  let text;
+  if (type === "undefined") text = "undefined";
+  else if (type === "bigint") text = String(value) + "n";
+  else if (type === "function" || type === "symbol") text = String(value);
+  else {
+    try {
+      text = JSON.stringify(value, function (_key, item) {
+        return typeof item === "bigint" ? String(item) + "n" : item;
+      }, 2);
+    } catch (_error) {
+      text = String(value);
+    }
+    if (text === undefined) text = String(value);
+  }
+  capture({ type: type, text: text });
+})()`;
+    }
+
+    function renderResult(result, returned, durationMs) {
+      const sections = [];
+      if (result.stdout) sections.push(`stdout\n${result.stdout.trimEnd()}`);
+      if (result.stderr) sections.push(`stderr\n${result.stderr.trimEnd()}`);
+      sections.push(returned ? `return (${returned.type})\n${returned.text}` : "return\n<not reached>");
+      output.value = sections.join("\n\n");
+
+      exit.textContent = `exit ${result.exitCode}`;
+      exit.dataset.state = result.exitCode === 0 ? "ok" : "error";
+      elapsed.textContent = `time ${durationMs.toFixed(1)} ms`;
+      memory.textContent = `wasm peak ${formatBytes(result.peakWasmMemoryBytes)} · initial ${formatBytes(result.initialWasmMemoryBytes)}`;
+
+      if (firstRun) {
+        firstRun = false;
+        smoke.textContent = result.exitCode === 0 &&
+          result.stdout.includes("hello from QuickJS") &&
+          result.stdout.includes("window: undefined") &&
+          returned?.text.includes('"answer": 42')
+            ? "PASS"
+            : "FAIL";
+      }
+    }
+
+    async function run() {
+      if (!engine) return;
+      runButton.disabled = true;
+      output.value = "Running inside QuickJS/WASM…";
+      exit.textContent = "running";
+      exit.dataset.state = "";
+      await new Promise(resolve => setTimeout(resolve, 0));
+
+      let returned;
+      const started = performance.now();
+      try {
+        const result = engine.runCode(guestProgram(source.value), {
+          globals: {
+            "playground.capture": value => {
+              returned = value;
+              return null;
+            },
+          },
+          wasmMemoryBytes: MEMORY_LIMIT_BYTES,
+          quickjsHeapBytes: 8 * 1024 * 1024,
+          timeoutMs: 1000,
+        });
+        renderResult(result, returned, performance.now() - started);
+      } catch (error) {
+        output.value = `host error\n${error instanceof Error ? error.stack : String(error)}`;
+        exit.textContent = "host error";
+        exit.dataset.state = "error";
+        elapsed.textContent = `time ${(performance.now() - started).toFixed(1)} ms`;
+      } finally {
+        runButton.disabled = false;
+      }
+    }
+
+    runButton.addEventListener("click", run);
+    resetButton.addEventListener("click", () => {
+      source.value = DEFAULT_SOURCE;
+      run();
+    });
+    source.addEventListener("keydown", event => {
+      if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+        event.preventDefault();
+        run();
+      }
+    });
+
+    try {
+      const response = await fetch("../../quickjs.wasm");
+      if (!response.ok) throw new Error(`could not load quickjs.wasm (${response.status})`);
+      engine = await createEngine(await response.arrayBuffer());
+      runButton.disabled = false;
+      await run();
+    } catch (error) {
+      output.value = `initialization error\n${error instanceof Error ? error.stack : String(error)}`;
+      exit.textContent = "load error";
+      exit.dataset.state = "error";
+      smoke.textContent = "FAIL";
+    }
+  </script>
+</body>
+</html>

--- a/tinysandbox-js-runtime/package-lock.json
+++ b/tinysandbox-js-runtime/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tinysandbox/js-runtime",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tinysandbox/js-runtime",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "esbuild": "^0.28.2",

--- a/tinysandbox-js-runtime/package.json
+++ b/tinysandbox-js-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinysandbox/js-runtime",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Stateless QuickJS runtime for standard WebAssembly hosts",
   "type": "module",
   "exports": {
@@ -12,10 +12,13 @@
   },
   "files": [
     "dist/",
+    "examples/browser/",
     "quickjs.wasm",
     "README.md",
     "LICENSE-APACHE",
-    "LICENSE-MIT"
+    "LICENSE-MIT",
+    "scripts/build-browser-site.mjs",
+    "scripts/serve-browser-example.mjs"
   ],
   "sideEffects": false,
   "engines": {
@@ -23,6 +26,8 @@
   },
   "scripts": {
     "build": "node scripts/build.mjs",
+    "build:site": "node scripts/build-browser-site.mjs",
+    "example:browser": "node scripts/serve-browser-example.mjs",
     "test": "npm run build && npm run typecheck && node --test test/*.test.mjs",
     "typecheck": "tsc -p tsconfig.json",
     "test:browser": "node test/browser-smoke.mjs",

--- a/tinysandbox-js-runtime/scripts/build-browser-site.mjs
+++ b/tinysandbox-js-runtime/scripts/build-browser-site.mjs
@@ -1,0 +1,24 @@
+import { copyFile, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+
+const output = new URL("../site-dist/", import.meta.url);
+const source = new URL("../examples/browser/index.html", import.meta.url);
+const runtime = new URL("../dist/index.js", import.meta.url);
+const wasm = new URL("../quickjs.wasm", import.meta.url);
+
+let html = await readFile(source, "utf8");
+const replacements = [
+  ["../../dist/index.js", "./runtime.js"],
+  ["../../quickjs.wasm", "./quickjs.wasm"],
+];
+for (const [from, to] of replacements) {
+  if (!html.includes(from)) throw new Error(`browser example is missing expected asset path ${from}`);
+  html = html.replaceAll(from, to);
+}
+
+await rm(output, { recursive: true, force: true });
+await mkdir(output, { recursive: true });
+await writeFile(new URL("index.html", output), html);
+await copyFile(runtime, new URL("runtime.js", output));
+await copyFile(wasm, new URL("quickjs.wasm", output));
+
+console.log("Cloudflare Pages site built in site-dist/");

--- a/tinysandbox-js-runtime/scripts/serve-browser-example.mjs
+++ b/tinysandbox-js-runtime/scripts/serve-browser-example.mjs
@@ -1,0 +1,40 @@
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { dirname, extname, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const packageRoot = dirname(dirname(fileURLToPath(import.meta.url)));
+const port = Number(process.env.PORT ?? 4173);
+if (!Number.isSafeInteger(port) || port < 1 || port > 65_535) {
+  throw new RangeError("PORT must be an integer between 1 and 65535");
+}
+
+const contentTypes = new Map([
+  [".html", "text/html; charset=utf-8"],
+  [".js", "text/javascript; charset=utf-8"],
+  [".mjs", "text/javascript; charset=utf-8"],
+  [".wasm", "application/wasm"],
+]);
+
+const server = createServer(async (request, response) => {
+  try {
+    const url = new URL(request.url ?? "/", "http://localhost");
+    const relative = url.pathname === "/"
+      ? "examples/browser/index.html"
+      : decodeURIComponent(url.pathname).replace(/^\/+/, "");
+    const path = resolve(packageRoot, relative);
+    if (path !== packageRoot && !path.startsWith(`${packageRoot}${sep}`)) {
+      throw new Error("path is outside the package root");
+    }
+    const body = await readFile(path);
+    response.setHeader("content-type", contentTypes.get(extname(path)) ?? "application/octet-stream");
+    response.end(body);
+  } catch (error) {
+    response.statusCode = 404;
+    response.end(error instanceof Error ? error.message : String(error));
+  }
+});
+
+server.listen(port, "127.0.0.1", () => {
+  console.log(`QuickJS/WASM playground: http://127.0.0.1:${port}/`);
+});

--- a/tinysandbox-js-runtime/test/browser-smoke.mjs
+++ b/tinysandbox-js-runtime/test/browser-smoke.mjs
@@ -3,13 +3,23 @@ import { createServer } from "node:http";
 import { readFile, stat } from "node:fs/promises";
 import { extname, join, normalize } from "node:path";
 
-const root = new URL("../", import.meta.url);
+const packageRoot = new URL("../", import.meta.url);
+const root = new URL("../site-dist/", import.meta.url);
 const chrome = process.env.CHROME_PATH ?? "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome";
 await stat(chrome);
 
+await new Promise((resolve, reject) => {
+  const child = spawn(process.execPath, ["scripts/build-browser-site.mjs"], {
+    cwd: packageRoot,
+    stdio: "inherit",
+  });
+  child.on("error", reject);
+  child.on("close", code => code === 0 ? resolve() : reject(new Error(`site build exited ${code}`)));
+});
+
 const server = createServer(async (request, response) => {
   try {
-    const pathname = request.url === "/" ? "/examples/browser/index.html" : request.url;
+    const pathname = request.url === "/" ? "/index.html" : request.url;
     const path = normalize(join(root.pathname, pathname));
     if (!path.startsWith(root.pathname)) throw new Error("outside fixture root");
     const content = await readFile(path);
@@ -33,7 +43,8 @@ try {
     child.on("error", reject);
     child.on("close", code => code === 0 ? resolve({ stdout, stderr }) : reject(new Error(`Chrome exited ${code}: ${stderr}`)));
   });
-  if (!output.includes('<pre id="result">PASS</pre>')) throw new Error(`browser smoke failed:\n${output}\n${chromeStderr}`);
+  if (!/<pre id="result"[^>]*>PASS<\/pre>/u.test(output)) throw new Error(`browser smoke failed:\n${output}\n${chromeStderr}`);
+  if (!output.includes('<body data-runtime="quickjs-wasm">')) throw new Error("browser example must identify the guest runtime");
   console.log("headless_chrome_smoke=PASS");
 } finally {
   server.close();


### PR DESCRIPTION
## Summary

- replace the browser smoke fixture with a minimal monospace two-pane playground
- execute editable source only inside fresh QuickJS/WASM instances and display stdout, stderr, the final expression value, exit status, elapsed time, and initial/peak WASM linear memory
- demonstrate isolation by showing `window` and `document` are unavailable, with a 16 MiB WASM cap, 8 MiB QuickJS heap cap, and one-second deadline
- include the example and zero-dependency local server in `@tinysandbox/js-runtime` 0.1.1
- add a static `build:site` output designed for Cloudflare Pages Git integration

## Cloudflare Pages

Configure the integration with:

- Framework preset: `None`
- Root directory: `tinysandbox-js-runtime`
- Build command: `npm run build:site`
- Build output directory: `site-dist`

Cloudflare Pages installs dependencies before invoking the build command. The output contains only `index.html`, `runtime.js`, and `quickjs.wasm`. No Pages Functions, Wrangler config, environment variables, or repository deployment workflow are needed.

## Verification

- `npm ci`
- `npm test` — 19 passing
- `npm run test:convex`
- `npm run test:browser` — runs headless Chrome against `site-dist`
- `npm pack --dry-run`
- unpacked the npm tarball and ran `npm run build:site` successfully
- interactive browser QA covered a custom return value, a 2 MiB guest allocation/peak-memory increase, unavailable DOM access, reset, and infinite-loop timeout containment