### PR TITLE
Link browser playground to GitHub repository

### DIFF
--- a/tinysandbox-js-runtime/examples/browser/index.html
+++ b/tinysandbox-js-runtime/examples/browser/index.html
@@ -53,14 +53,36 @@
       color: var(--muted);
     }
 
-    .runtime {
+    .header-meta {
+      display: flex;
+      align-items: stretch;
+      gap: 8px;
       flex: none;
+    }
+
+    .runtime,
+    .repository {
       border: 1px solid var(--line);
       padding: 8px 10px;
-      color: var(--accent);
       font-size: 11px;
       letter-spacing: 0.08em;
       text-transform: uppercase;
+    }
+
+    .runtime { color: var(--accent); }
+
+    .repository {
+      display: flex;
+      align-items: center;
+      color: var(--text);
+      text-decoration: none;
+    }
+
+    .repository:hover,
+    .repository:focus-visible {
+      border-color: var(--accent);
+      color: var(--accent);
+      outline: none;
     }
 
     .workspace {
@@ -150,7 +172,7 @@
     @media (max-width: 760px) {
       main { padding: 18px; }
       header { display: block; }
-      .runtime { display: inline-block; margin-top: 16px; }
+      .header-meta { display: inline-flex; margin-top: 16px; }
       .workspace { grid-template-columns: 1fr; }
       section + section { border-left: 0; border-top: 1px solid var(--line); }
       textarea { height: 42vh; min-height: 280px; }
@@ -164,7 +186,10 @@
         <h1>tinysandbox / js</h1>
         <p>Source runs in a fresh QuickJS instance inside WebAssembly. Browser globals, DOM, filesystem, and network capabilities are not exposed.</p>
       </div>
-      <div class="runtime">host: V8 · guest: QuickJS/WASM</div>
+      <div class="header-meta">
+        <div class="runtime">host: V8 · guest: QuickJS/WASM</div>
+        <a class="repository" href="https://github.com/danthegoodman1/tinysandbox" target="_blank" rel="noreferrer">GitHub ↗</a>
+      </div>
     </header>
 
     <div class="workspace">

--- a/tinysandbox-js-runtime/package-lock.json
+++ b/tinysandbox-js-runtime/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@tinysandbox/js-runtime",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@tinysandbox/js-runtime",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT OR Apache-2.0",
       "devDependencies": {
         "esbuild": "^0.28.2",

--- a/tinysandbox-js-runtime/package.json
+++ b/tinysandbox-js-runtime/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tinysandbox/js-runtime",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Stateless QuickJS runtime for standard WebAssembly hosts",
   "type": "module",
   "exports": {

--- a/tinysandbox-js-runtime/test/browser-smoke.mjs
+++ b/tinysandbox-js-runtime/test/browser-smoke.mjs
@@ -45,6 +45,7 @@ try {
   });
   if (!/<pre id="result"[^>]*>PASS<\/pre>/u.test(output)) throw new Error(`browser smoke failed:\n${output}\n${chromeStderr}`);
   if (!output.includes('<body data-runtime="quickjs-wasm">')) throw new Error("browser example must identify the guest runtime");
+  if (!output.includes('href="https://github.com/danthegoodman1/tinysandbox"')) throw new Error("browser example must link to the repository");
   console.log("headless_chrome_smoke=PASS");
 } finally {
   server.close();


### PR DESCRIPTION
## Summary

- add a compact GitHub repository link to the browser playground header
- keep the link responsive and keyboard-visible within the existing monospace design
- cover the repository URL in the headless browser smoke test
- bump `@tinysandbox/js-runtime` to `0.1.2`

## Validation

- `npm test`
- `npm run test:convex`
- `npm run build:site`
- `npm run test:browser`
- `npm pack --dry-run --cache /tmp/tinysandbox-js-runtime-npm-cache`