### PR TITLE
docs: describe current WebAssembly footprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,9 +303,9 @@ identical output):
 | Limits | Per-run memory cap (default 64 MB) with clean OOM errors, CPU deadline via epoch interruption (`while(true){}` exits 124), fetch response body cap, catchable `RangeError` on stack exhaustion |
 
 The checked-in module starts with 19 WebAssembly pages (1,245,184 bytes, or
-1.1875 MiB) of linear memory, down from the previous 67-page/4.19 MiB floor.
-The build links a 1 MiB C stack and gives QuickJS a 768 KiB stack limit so
-exhaustion remains a catchable JavaScript exception. Run
+1.1875 MiB) of linear memory. The build links a 1 MiB C stack and gives QuickJS
+a 768 KiB stack limit so exhaustion remains a catchable JavaScript exception.
+Run
 `node scripts/inspect-quickjs-wasm.mjs` to report the exact artifact size,
 initial memory, imports, and exports. Initial linear memory is a deterministic
 capacity floor; it is not an RSS measurement and unused pages may be committed
@@ -1279,24 +1279,22 @@ RSS includes runtime and allocator overhead for that process.
 
 Nothing compiles wasm at run time. The build script turns `quickjs.wasm` into
 machine code for the crate's target and the binary embeds the result, so the
-first `js` command loads an artifact that is already executable. Doing that work
-during the build is worth about 425 ms and 29 MiB per process.
+first `js` command loads an artifact that is already executable.
 
-What a process pays, measured on Linux x86_64 with `wasmtime` 46:
+Runtime behavior with `wasmtime` 46:
 
-| Step | When | Cost |
-| --- | --- | --- |
-| First `js` command in a process | loads the artifact | ~9 ms, ~8.4 MiB RSS |
-| The same first command, on the fallback path | only when the artifact is refused | ~430 ms, ~31 MiB RSS |
-| One in-flight `js` command | every run | ~3.4 ms, ~0.5 MiB RSS |
-| Sandbox with no `js` command running | — | ~7 KiB, no runtime cost |
+| Step | Behavior |
+| --- | --- |
+| First `js` command in a process | Loads the embedded precompiled artifact. |
+| Fallback first command | Compiles the checked-in wasm when the embedded artifact is refused. |
+| One in-flight `js` command | Owns fresh wasm and QuickJS state for that run. |
+| Sandbox with no `js` command running | Retains no per-command QuickJS state. |
 
-These RSS samples predate the reduction from 67 initial wasm pages to 19. The
-repository does not currently have a repeatable in-flight-JavaScript RSS
-harness, so no RSS saving is inferred from the page reduction: the hard,
-reproducible change is a 3,145,728-byte reduction in initial linear-memory
-capacity per active run. The runtime still creates and destroys QuickJS for
-each `js` command, so idle sandbox memory is unchanged.
+Each active run starts with 1,245,184 bytes of linear-memory capacity. This is a
+deterministic capacity floor, not an RSS measurement, and unused pages may be
+committed lazily by the operating system. The repository does not have a
+repeatable in-flight-JavaScript RSS harness, so it does not publish an RSS
+estimate for active JavaScript runs.
 
 The artifact is pinned to the target triple with that architecture's baseline
 CPU features, so it runs on any CPU of that architecture rather than only one as

--- a/tinysandbox-js-runtime/test/browser-smoke.mjs
+++ b/tinysandbox-js-runtime/test/browser-smoke.mjs
@@ -17,12 +17,38 @@ await new Promise((resolve, reject) => {
   child.on("close", code => code === 0 ? resolve() : reject(new Error(`site build exited ${code}`)));
 });
 
+const indexHtml = await readFile(join(root.pathname, "index.html"), "utf8");
+if (!indexHtml.includes('<body data-runtime="quickjs-wasm">')) throw new Error("browser example must identify the guest runtime");
+if (!indexHtml.includes('href="https://github.com/danthegoodman1/tinysandbox"')) throw new Error("browser example must link to the repository");
+
+let reportSmoke;
+const smokeResult = new Promise(resolve => { reportSmoke = resolve; });
 const server = createServer(async (request, response) => {
   try {
-    const pathname = request.url === "/" ? "/index.html" : request.url;
+    const requestUrl = new URL(request.url ?? "/", "http://127.0.0.1");
+    if (requestUrl.pathname === "/__smoke__") {
+      response.end("ok");
+      reportSmoke(requestUrl.searchParams.get("result") ?? "");
+      return;
+    }
+    const pathname = requestUrl.pathname === "/" ? "/index.html" : requestUrl.pathname;
     const path = normalize(join(root.pathname, pathname));
     if (!path.startsWith(root.pathname)) throw new Error("outside fixture root");
-    const content = await readFile(path);
+    let content = await readFile(path);
+    if (pathname === "/index.html") {
+      content = Buffer.from(content.toString("utf8").replace("</body>", `<script>
+        const smokeResult = document.querySelector("#result");
+        let smokeReported = false;
+        const report = () => {
+          if (!smokeReported && smokeResult.textContent !== "RUNNING") {
+            smokeReported = true;
+            fetch("/__smoke__?result=" + encodeURIComponent(smokeResult.textContent));
+          }
+        };
+        new MutationObserver(report).observe(smokeResult, { childList: true });
+        report();
+      </script>\n</body>`));
+    }
     response.setHeader("content-type", extname(path) === ".wasm" ? "application/wasm" : [".js", ".mjs"].includes(extname(path)) ? "text/javascript" : "text/html");
     response.end(content);
   } catch (error) {
@@ -33,20 +59,29 @@ const server = createServer(async (request, response) => {
 await new Promise(resolve => server.listen(0, "127.0.0.1", resolve));
 const { port } = server.address();
 
+let child;
+let timeout;
 try {
-  const { stdout: output, stderr: chromeStderr } = await new Promise((resolve, reject) => {
-    const child = spawn(chrome, ["--headless", "--disable-gpu", "--no-first-run", "--enable-logging=stderr", "--virtual-time-budget=30000", "--dump-dom", `http://127.0.0.1:${port}/`]);
-    let stdout = "";
-    let stderr = "";
-    child.stdout.on("data", chunk => { stdout += chunk; });
-    child.stderr.on("data", chunk => { stderr += chunk; });
-    child.on("error", reject);
-    child.on("close", code => code === 0 ? resolve({ stdout, stderr }) : reject(new Error(`Chrome exited ${code}: ${stderr}`)));
-  });
-  if (!/<pre id="result"[^>]*>PASS<\/pre>/u.test(output)) throw new Error(`browser smoke failed:\n${output}\n${chromeStderr}`);
-  if (!output.includes('<body data-runtime="quickjs-wasm">')) throw new Error("browser example must identify the guest runtime");
-  if (!output.includes('href="https://github.com/danthegoodman1/tinysandbox"')) throw new Error("browser example must link to the repository");
+  child = spawn(chrome, ["--headless", "--disable-gpu", "--no-first-run", "--enable-logging=stderr", `http://127.0.0.1:${port}/`], { stdio: ["ignore", "ignore", "pipe"] });
+  let chromeStderr = "";
+  child.stderr.on("data", chunk => { chromeStderr += chunk; });
+  const result = await Promise.race([
+    smokeResult,
+    new Promise((_, reject) => {
+      child.on("error", reject);
+      child.on("close", code => reject(new Error(`Chrome exited ${code}: ${chromeStderr}`)));
+    }),
+    new Promise((_, reject) => {
+      timeout = setTimeout(() => reject(new Error(`browser smoke timed out:\n${chromeStderr}`)), 60_000);
+    }),
+  ]);
+  if (result !== "PASS") throw new Error(`browser smoke failed: ${result}\n${chromeStderr}`);
   console.log("headless_chrome_smoke=PASS");
 } finally {
-  server.close();
+  clearTimeout(timeout);
+  if (child && child.exitCode === null && child.signalCode === null) {
+    child.kill();
+    await new Promise(resolve => child.once("close", resolve));
+  }
+  await new Promise((resolve, reject) => server.close(error => error ? reject(error) : resolve()));
 }

--- a/tinysandbox-js-runtime/test/browser-smoke.mjs
+++ b/tinysandbox-js-runtime/test/browser-smoke.mjs
@@ -35,7 +35,7 @@ const { port } = server.address();
 
 try {
   const { stdout: output, stderr: chromeStderr } = await new Promise((resolve, reject) => {
-    const child = spawn(chrome, ["--headless", "--disable-gpu", "--no-first-run", "--enable-logging=stderr", "--virtual-time-budget=5000", "--dump-dom", `http://127.0.0.1:${port}/`]);
+    const child = spawn(chrome, ["--headless", "--disable-gpu", "--no-first-run", "--enable-logging=stderr", "--virtual-time-budget=30000", "--dump-dom", `http://127.0.0.1:${port}/`]);
     let stdout = "";
     let stderr = "";
     child.stdout.on("data", chunk => { stdout += chunk; });


### PR DESCRIPTION
## Summary

- describe the checked-in QuickJS WebAssembly memory floor without historical comparisons
- replace obsolete pre-reduction RSS figures with current runtime behavior
- keep the deterministic capacity-versus-RSS distinction explicit
- make the browser smoke test wait for a bounded readiness signal instead of relying on Chrome virtual-time timing

## Validation

- node scripts/inspect-quickjs-wasm.mjs
- node scripts/release-version.mjs check 0.6.5
- node scripts/release-version.mjs next --bump patch (0.6.6)
- npm --prefix tinysandbox-js-runtime test
- npm --prefix tinysandbox-js-runtime run test:convex
- npm --prefix tinysandbox-js-runtime run test:browser (three consecutive passes)
- npm pack --dry-run (from tinysandbox-js-runtime)
- git diff --check

## Release

Merging to main triggers the automated patch release. The release workflow will apply version 0.6.6; versions are intentionally not pre-bumped in this PR so the workflow does not bump twice.